### PR TITLE
Fix problem with es index version when no indices exist

### DIFF
--- a/backend/es/es_alias.py
+++ b/backend/es/es_alias.py
@@ -105,6 +105,7 @@ def get_highest_version_number(indices, current_index=None):
     if type(indices) is list:
         raise RuntimeError('`indices` should not be list')
     versions = [extract_version(index_name, current_index) for index_name in indices.keys()]
-    if len(versions):
+    try:
         return max([v for v in versions if v is not None])
-    return 0
+    except:
+        return 0

--- a/backend/es/tests/test_alias.py
+++ b/backend/es/tests/test_alias.py
@@ -28,3 +28,7 @@ def test_highest_version_number(es_alias_client):
     current_index = 'times-test'
     num = get_highest_version_number(indices, current_index)
     assert num == 2
+    current_index = "fantasy-index-name"
+    indices = es_alias_client.indices.get(index="{}-*".format(current_index))
+    num = get_highest_version_number(indices, current_index)
+    assert num == 0


### PR DESCRIPTION
The first attempt to index with the new alias / versioning strategy triggered an error, as there were not any indices yet under the alias. This branch fixes that.