### PR TITLE
Overhaul GitHub actions once more

### DIFF
--- a/.github/workflows/backend-build-and-push.yml
+++ b/.github/workflows/backend-build-and-push.yml
@@ -1,0 +1,32 @@
+name: Backend build and push after merge of requirements.txt
+
+on:
+    pull_request:
+      branches:
+        - develop
+      types:
+        - closed
+      paths:
+        - backend/requirements.txt
+
+jobs:
+  if_merged:
+    name: Build and push backend image
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Backend
+      uses: docker/build-push-action@v6
+      with:
+        context: backend/.
+        push: true
+        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest

--- a/.github/workflows/backend-build-and-push.yml
+++ b/.github/workflows/backend-build-and-push.yml
@@ -1,6 +1,7 @@
 name: Backend build and push after merge of requirements.txt
 
 on:
+    workflow_dispatch:
     pull_request:
       branches:
         - develop

--- a/.github/workflows/backend-build-and-push.yml
+++ b/.github/workflows/backend-build-and-push.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         context: backend/.
         push: true
-        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
+        tags: ghcr.io/centrefordigitalhumanities/ianalyzer-backend:latest

--- a/.github/workflows/backend-build-and-push.yml
+++ b/.github/workflows/backend-build-and-push.yml
@@ -8,6 +8,7 @@ on:
         - closed
       paths:
         - backend/requirements.txt
+        - 'docker-compose.yaml'
 
 jobs:
   if_merged:

--- a/.github/workflows/backend-build-and-push.yml
+++ b/.github/workflows/backend-build-and-push.yml
@@ -1,7 +1,6 @@
 name: Backend build and push after merge of requirements.txt
 
 on:
-    workflow_dispatch:
     pull_request:
       branches:
         - develop

--- a/.github/workflows/backend-build-and-test.yml
+++ b/.github/workflows/backend-build-and-test.yml
@@ -1,20 +1,17 @@
-# This workflow will run backend tests using the `ianalyzer-backend:latest` image
+# This workflow will build the backend container and then run tests; it will only be triggered when requirements change
 
-name: Backend unit tests
+name: Build backend and run unit tests
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - 'develop'
-      - 'master'
       - 'feature/**'
       - 'bugfix/**'
       - 'hotfix/**'
-      - 'release/**'
+      - 'dependabot/**'
     paths:
-      - 'backend/**'
-      - '.github/workflows/backend-test.yml'
+      - 'backend/requirements.txt'
       - 'docker-compose.yaml'
 
 jobs:
@@ -26,4 +23,4 @@ jobs:
     - name: Run backend tests
       run: |
         sudo mkdir -p /ci-data
-        docker compose --env-file .env-ci run backend pytest
+        docker compose --env-file .env-ci run --build backend pytest

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -15,7 +15,7 @@ on:
       - 'dependabot/**'
     paths:
       - 'backend/**'
-      - '.github/workflows/backend*'
+      - '.github/workflows/backend-test.yml'
       - 'docker-compose.yaml'
 
 jobs:
@@ -27,5 +27,4 @@ jobs:
     - name: Run backend tests
       run: |
         sudo mkdir -p /ci-data
-        docker compose pull elasticsearch
-        docker compose --env-file .env-ci run --rm backend pytest
+        docker compose --env-file .env-ci run --build backend pytest

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -24,34 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push Elasticsearch image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: DockerfileElastic
-        push: true
-        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-elastic:latest
-        cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-elastic:latest
-        cache-to: type=inline
-    - name: Build and push Backend
-      uses: docker/build-push-action@v6
-      with:
-        context: backend/.
-        push: true
-        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
-        cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
-        cache-to: type=inline
     - name: Run backend tests
       run: |
         sudo mkdir -p /ci-data
         docker compose pull elasticsearch
-        docker compose pull backend
         docker compose --env-file .env-ci run --rm backend pytest

--- a/.github/workflows/frontend-build-and-push.yml
+++ b/.github/workflows/frontend-build-and-push.yml
@@ -8,6 +8,7 @@ on:
         - closed
       paths:
         - frontend/yarn.lock
+        - 'docker-compose.yaml'
 
 jobs:
   if_merged:

--- a/.github/workflows/frontend-build-and-push.yml
+++ b/.github/workflows/frontend-build-and-push.yml
@@ -1,6 +1,7 @@
 name: Frontend build and push after merge of yarn.lock
 
 on:
+    workflow_dispatch:
     pull_request:
       branches:
         - develop

--- a/.github/workflows/frontend-build-and-push.yml
+++ b/.github/workflows/frontend-build-and-push.yml
@@ -1,0 +1,34 @@
+name: Frontend build and push after merge of yarn.lock
+
+on:
+    pull_request:
+      branches:
+        - develop
+      types:
+        - closed
+      paths:
+        - frontend/yarn.lock
+
+jobs:
+  if_merged:
+    name: Build and push frontend image
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build frontend image, using cache from Github registry
+      uses: docker/build-push-action@v6
+      with:
+        context: frontend/.
+        push: true
+        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+        cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+        cache-to: type=inline

--- a/.github/workflows/frontend-build-and-push.yml
+++ b/.github/workflows/frontend-build-and-push.yml
@@ -1,7 +1,6 @@
 name: Frontend build and push after merge of yarn.lock
 
 on:
-    workflow_dispatch:
     pull_request:
       branches:
         - develop

--- a/.github/workflows/frontend-build-and-push.yml
+++ b/.github/workflows/frontend-build-and-push.yml
@@ -30,6 +30,6 @@ jobs:
       with:
         context: frontend/.
         push: true
-        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
-        cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+        tags: ghcr.io/centrefordigitalhumanities/ianalyzer-frontend:latest
+        cache-from: type=registry,ref=ghcr.io/centrefordigitalhumanities/ianalyzer-frontend:latest
         cache-to: type=inline

--- a/.github/workflows/frontend-build-and-test.yml
+++ b/.github/workflows/frontend-build-and-test.yml
@@ -1,4 +1,4 @@
-# This workflow will run frontend tests on the `ianalyzer-frontend:latest` image
+# This workflow will build the frontend container and then run tests; it will only be triggered when yarn.lock changes
 
 name: Frontend unit tests
 
@@ -6,16 +6,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'develop'
-      - 'master'
       - 'feature/**'
       - 'bugfix/**'
       - 'hotfix/**'
-      - 'release/**'
       - 'dependabot/**'
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-test.yml'
+      - frontend/yarn.lock
       - 'docker-compose.yaml'
 
 jobs:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -24,23 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build frontend image, using cache from Github registry
-      uses: docker/build-push-action@v6
-      with:
-        context: frontend/.
-        push: true
-        tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
-        cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
-        cache-to: type=inline
     - name: Run frontend unit tests
       run: |
-        docker compose pull frontend
         docker compose --env-file .env-ci run --rm frontend yarn test

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -15,7 +15,7 @@ on:
       - 'dependabot/**'
     paths:
       - 'frontend/**'
-      - '.github/workflows/frontend*'
+      - '.github/workflows/frontend-test.yml'
       - 'docker-compose.yaml'
 
 jobs:
@@ -26,4 +26,4 @@ jobs:
     - uses: actions/checkout@v4
     - name: Run frontend unit tests
       run: |
-        docker compose --env-file .env-ci run --rm frontend yarn test
+        docker compose --env-file .env-ci run --build frontend yarn test

--- a/.github/workflows/scheduled-build-and-push.yml
+++ b/.github/workflows/scheduled-build-and-push.yml
@@ -1,0 +1,47 @@
+# This workflow will run every first of the month, to make sure we update the underlying images and libraries
+
+name: Scheduled build and push of all images
+
+on:
+    schedule:
+        - cron: "0 0 1 * *"
+
+jobs:
+    rebuild-scheduled:
+        name: Rebuild images
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+        - name: Login to GitHub Container Registry
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build frontend image, using cache from Github registry
+          uses: docker/build-push-action@v6
+          with:
+            context: frontend/.
+            push: true
+            tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+            cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+            cache-to: type=inline
+        - name: Build backend image, using cache from Github registry
+          uses: docker/build-push-action@v6
+          with:
+            context: backend/.
+            push: true
+            tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
+            cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
+            cache-to: type=inline
+        - name: Build Elasticsearch image, using cache from Github registry
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            dockerfile: DockerfileElastic
+            push: true
+            tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-elasticsearch:latest
+            cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-elasticsearch:latest
+            cache-to: type=inline

--- a/.github/workflows/scheduled-build-and-push.yml
+++ b/.github/workflows/scheduled-build-and-push.yml
@@ -25,16 +25,16 @@ jobs:
           with:
             context: frontend/.
             push: true
-            tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
-            cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+            tags: ghcr.io/centrefordigitalhumanities/ianalyzer-frontend:latest
+            cache-from: type=registry,ref=ghcr.io/centrefordigitalhumanities/ianalyzer-frontend:latest
             cache-to: type=inline
         - name: Build backend image, using cache from Github registry
           uses: docker/build-push-action@v6
           with:
             context: backend/.
             push: true
-            tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
-            cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
+            tags: ghcr.io/centrefordigitalhumanities/ianalyzer-backend:latest
+            cache-from: type=registry,ref=ghcr.io/centrefordigitalhumanities/ianalyzer-backend:latest
             cache-to: type=inline
         - name: Build Elasticsearch image, using cache from Github registry
           uses: docker/build-push-action@v6
@@ -42,6 +42,6 @@ jobs:
             context: .
             dockerfile: DockerfileElastic
             push: true
-            tags: ghcr.io/uudigitalhumanitieslab/ianalyzer-elasticsearch:latest
-            cache-from: type=registry,ref=ghcr.io/uudigitalhumanitieslab/ianalyzer-elasticsearch:latest
+            tags: ghcr.io/centrefordigitalhumanities/ianalyzer-elasticsearch:latest
+            cache-from: type=registry,ref=ghcr.io/centrefordigitalhumanities/ianalyzer-elasticsearch:latest
             cache-to: type=inline

--- a/.github/workflows/scheduled-build-and-push.yml
+++ b/.github/workflows/scheduled-build-and-push.yml
@@ -3,6 +3,7 @@
 name: Scheduled build and push of all images
 
 on:
+    workflow_dispatch:
     schedule:
         - cron: "0 0 1 * *"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ianalyzer-db:/var/lib/postgresql/data/
   backend:
-    image: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
+    image: ghcr.io/centrefordigitalhumanities/ianalyzer-backend:latest
     build:
       context: ./backend
     depends_on:
@@ -40,7 +40,7 @@ services:
         target: /corpora
     command: bash -c "python manage.py migrate && python manage.py loadcorpora && python manage.py runserver 0.0.0.0:8000"
   frontend:
-    image: ghcr.io/uudigitalhumanitieslab/ianalyzer-frontend:latest
+    image: ghcr.io/centrefordigitalhumanities/ianalyzer-frontend:latest
     build:
       context: ./frontend
     ports:
@@ -54,7 +54,7 @@ services:
         target: /frontend/build
     command: sh -c "yarn prebuild && yarn start-docker"
   elasticsearch:
-    image: ghcr.io/uudigitalhumanitieslab/ianalyzer-elastic:latest
+    image: ghcr.io/centrefordigitalhumanities/ianalyzer-elastic:latest
     build:
       context: .
       dockerfile: DockerfileElastic
@@ -82,7 +82,7 @@ services:
     image: redis:latest
     restart: unless-stopped
   celery:
-    image: ghcr.io/uudigitalhumanitieslab/ianalyzer-backend:latest
+    image: ghcr.io/centrefordigitalhumanities/ianalyzer-backend:latest
     environment:
       CELERY_BROKER: $CELERY_BROKER
       SQL_DATABASE: $SQL_DATABASE


### PR DESCRIPTION
This branch reworks the current strategy of GitHub actions, which often fail due to failed pushes to the registry. It tries to limit the pushes to the registry with the following strategy:
- every push to `feature/**`, `bugfix/**`, `hotfix/**`, `release/**`, `develop` and `master` will trigger a test action, using the `:latest` image of frontend / backend / elasticsearch, respectively.
- in dependabot/feature/bugfix/hotfix branches: when `requirements.txt` or `yarn.lock` have been touched, another action will be triggered: we will run tests *without* using the image, this to avoid failing tests due to missing / outdated libraries. Unfortunately I cannot see how I would then avoid still triggering the above action, as it does not seem we can tell GHA to run actions "if this path is changed, but absolutely not if this other path is changed".
- when merging PR's with changes to requirements or yarn.lock to develop, a new image with :latest tag will be built and pushed
- every month, a new set of images for frontend, backend and elasticsearch will be generated and pushed to the `:latest` tags

Does this make sense, @tymees ?

I'm also wondering whether to use build stages after all in the Dockerfiles, then the "scheduled" workflow could more specifically target only the part of the images prior to installing with `pip` or `yarn`, but then I'm not sure how I could get the other actions to build on top of that image.

Another open question: does the `cache-to` and `cache-from` in the actions actually still make sense? I *do* sometimes see `CACHED` in the action reports, but I'm not sure when this would actually happen, as it seems every time an action builds, it will actually push to a new hashed version of the image.