### PR TITLE
add survey link

### DIFF
--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -1,3 +1,9 @@
+<div class="message">
+    <p class="message-body has-text-right">
+        Participate in the <a href="https://survey.uu.nl/jfe/form/SV_1HRZ0Vel6gjVXJs">I-analyzer user survey!</a>
+    </p>
+</div>
+
 <div [class.is-loading]="isLoading | async">
     <ia-corpus-selection [items]="items"></ia-corpus-selection>
 </div>


### PR DESCRIPTION
Adds a message to point users to our user survey. The plan is to keep this message up for a month or so and then remove it.

This solution is very low-tech - the message can't be dismissed but it's also not too distracting or obtrusive.

![screenshot of I-analyzer home page showing message with link: "participate in the I-analyzer user survey"](https://github.com/user-attachments/assets/e8356311-cdca-4326-aa05-3fd60b9da09d)

This only appears on the home page, not on the search interface. I'm hoping that that way, users will see it but it won't get annoying.