### PR TITLE
set minimum size for terms aggregation in visualisation

### DIFF
--- a/frontend/src/app/visualization/barchart/histogram.component.ts
+++ b/frontend/src/app/visualization/barchart/histogram.component.ts
@@ -41,19 +41,16 @@ export class HistogramComponent
      * used in document requests.
      */
     getAggregator(): TermsAggregator {
-        let size = 0;
-
-        if (!this.visualizedField.filterOptions) {
-            return new TermsAggregator(this.visualizedField, 100);
-        }
+        let size = 100;
 
         const filterOptions = this.visualizedField.filterOptions;
         if (filterOptions.name === 'MultipleChoiceFilter') {
             size = (filterOptions as MultipleChoiceFilterOptions).option_count;
         } else if (filterOptions.name === 'RangeFilter') {
-            size =
+            const filterRange =
                 (filterOptions as RangeFilterOptions).upper -
                 (filterOptions as RangeFilterOptions).lower;
+            size = _.max([size, filterRange])
         }
         return new TermsAggregator(this.visualizedField, size);
     }


### PR DESCRIPTION
close #1683

Fixes the number of documents / term frequency visualisations for numeric fields without an upper/lower bound configured. Also addresses an issue with float fields where the number of values may be more than `upper - lower`.

Fix: ensure that the bin limit is at least 100.

The result still isn't great, to be honest. In a corpus like DBNL, you get the top 100 years, which is a bit weird in a 700-year range. The proper fix would be to use a [histogram aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html) rather than a [terms aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html). But that would be a lot more work.
