### PR TITLE
Add Estimated Centuries filter in Jewish Migration

### DIFF
--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -9,6 +9,7 @@ import requests
 from addcorpus.python_corpora.corpus import JSONCorpusDefinition, FieldDefinition
 from addcorpus.es_mappings import int_mapping, keyword_mapping
 import addcorpus.python_corpora.extract as extract
+from addcorpus.python_corpora.filters import MultipleChoiceFilter
 from corpora.peaceportal.peaceportal import PeacePortal
 from corpora.utils.exclude_fields import exclude_fields_without_extractor
 
@@ -27,19 +28,6 @@ def transform_language(language_array):
             continue
     return output
 
-
-def transform_centuries(century_array):
-    ''' transform each item of the century array to integer
-    abort if values such as "unknown" appear in the array '''
-    if not century_array:
-        return None
-    output = []
-    for item in century_array:
-        try:
-            output.append(int(item))
-        except:
-            return None
-    return output
 
 class JewishMigration(PeacePortal, JSONCorpusDefinition):
     ''' Class for indexing Jewish Migration data '''
@@ -130,9 +118,11 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
                 name="estimated_centuries",
                 display_name="Estimated Centuries",
                 description="Estimate of centuries in which the inscription was made",
-                es_mapping=int_mapping(),
-                extractor=extract.JSON(
-                    key="estimated_centuries", transform=transform_centuries
+                es_mapping=keyword_mapping(),
+                extractor=extract.JSON(key="estimated_centuries"),
+                search_filter=MultipleChoiceFilter(
+                    description="Search only within these estimated centuries.",
+                    option_count=4,
                 ),
             ),
             FieldDefinition(

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -124,6 +124,7 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
                     description="Search only within these estimated centuries.",
                     option_count=4,
                 ),
+                visualizations=["resultscount"],
             ),
             FieldDefinition(
                 name="inscription_count",

--- a/backend/corpora/jewishmigration/test_jewishmigration.py
+++ b/backend/corpora/jewishmigration/test_jewishmigration.py
@@ -113,15 +113,12 @@ EXPECTED_DOCUMENT = {
     "region": "Africa Proconsularis ",
     "coordinates": {
         "type": "Point",
-        "coordinates": [
-            36.36811466666666,
-            6.613302666666667
-        ]
+        "coordinates": [36.36811466666666, 6.613302666666667],
     },
     "site_type": "Inscription",
     "inscription_type": "Epitaph",
     "period": "II AD",
-    "estimated_centuries": [2, 3],
+    "estimated_centuries": ['2', '3'],
     "inscription_count": 1,
     "religious_profession": "",
     "sex_dedicator": "",
@@ -129,7 +126,7 @@ EXPECTED_DOCUMENT = {
     "iconography": "",
     "comments": "",
     "transcription": "",
-    "transcription_en": "To the shadows of the underworld Julia Victoria the Jewess(?) CV"
+    "transcription_en": "To the shadows of the underworld Julia Victoria the Jewess(?) CV",
 }
 
 @pytest.fixture


### PR DESCRIPTION
This branch makes sure that the "Estimated Centuries" field can be filtered on, useful to compare the map over time.

<img width="1231" alt="Screenshot 2024-11-07 at 16 19 25" src="https://github.com/user-attachments/assets/d580c317-a8c5-41ec-84bd-efaca4681959">

Note: for this to work properly, will need to reindex the JewishMigration corpus once more, to convert from integer to keyword field.