### PR TITLE
Gallica: automate restart after failed HTTP requests

### DIFF
--- a/backend/corpora/gallica/conftest.py
+++ b/backend/corpora/gallica/conftest.py
@@ -21,6 +21,10 @@ class MockResponse(object):
         with open(self.mock_content_file, "r") as f:
             return f.read()
 
+    @property
+    def status_code(self):
+        return 200
+
 
 def mock_response(url: str) -> MockResponse:
     if url.endswith("date"):
@@ -33,3 +37,6 @@ def mock_response(url: str) -> MockResponse:
         filename = os.path.join(here, "tests", "data", "figaro", "RoughText.html")
     return MockResponse(filename)
 
+
+def mock_sleep(seconds: int):
+    pass

--- a/backend/corpora/gallica/figaro.py
+++ b/backend/corpora/gallica/figaro.py
@@ -22,7 +22,7 @@ class Figaro(Gallica):
     title = "Le Figaro"
     description = "Newspaper archive, 1854-1953"
     min_date = datetime(year=1854, month=1, day=1)
-    max_date = datetime(year=1953, month=12, day=31)
+    max_date = datetime(year=1954, month=12, day=31)
     corpus_id = "cb34355551z"
     category = "periodical"
     es_index = getattr(settings, 'FIGARO_INDEX', 'figaro')

--- a/backend/corpora/gallica/gallica.py
+++ b/backend/corpora/gallica/gallica.py
@@ -65,8 +65,8 @@ class Gallica(XMLCorpusDefinition):
                 if int(year.string) >= start.year and int(year.string) <= end.year
             ]
         for year in years:
-            for _n in range(self.n_retries):
-                sleep(30)
+            for retry in range(self.n_retries):
+                sleep(retry * 10)
                 try:
                     response = requests.get(
                         f"{self.data_url}/services/Issues?ark=ark:/12148/{self.corpus_id}/date&date={year}"
@@ -79,13 +79,13 @@ class Gallica(XMLCorpusDefinition):
                         break
                 except RequestsConnectionError:
                     logger.warning(
-                        f"Connection error when processing year {year}, going to sleep"
+                        f"Connection error when processing year {year}, going to sleep for {retry * 10} seconds"
                     )
                     continue
 
             for ark in ark_numbers:
-                for _n in range(self.n_retries):
-                    sleep(30)
+                for retry in range(self.n_retries):
+                    sleep(retry * 10)
                     try:
                         source_response = requests.get(
                             f"{self.data_url}/services/OAIRecord?ark={ark}"
@@ -94,11 +94,11 @@ class Gallica(XMLCorpusDefinition):
                             break
                     except RequestsConnectionError:
                         logger.warning(
-                            f"Connection error encountered in issue {ark}, going to sleep"
+                            f"Connection error encountered in issue {ark}, going to sleep for {retry * 10} seconds"
                         )
                         continue
-                for _n in range(self.n_retries):
-                    sleep(30)
+                for retry in range(self.n_retries):
+                    sleep(retry * 10)
                     try:
                         content_response = requests.get(
                             f"{self.data_url}/ark:/12148/{ark}.texteBrut"
@@ -110,7 +110,7 @@ class Gallica(XMLCorpusDefinition):
                             break
                     except RequestsConnectionError:
                         logger.warning(
-                            f"Connection error when fetching full text of issue {ark}, going to sleep"
+                            f"Connection error when fetching full text of issue {ark}, going to sleep for {retry * 10} seconds"
                         )
                         continue
                 yield (

--- a/backend/corpora/gallica/gallica.py
+++ b/backend/corpora/gallica/gallica.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+import os.path as op
 from time import sleep
 
 from bs4 import BeautifulSoup
@@ -41,6 +42,9 @@ class Gallica(XMLCorpusDefinition):
     data_url = "https://gallica.bnf.fr"
     corpus_id = ""  # each corpus on Gallica has an "ark" id
     n_retries = 5
+    data_directory = op.dirname(
+        op.abspath(__file__)
+    )  # make sure that all corpora have a data_directory assigned
 
     @property
     def es_settings(self):

--- a/backend/corpora/gallica/tests/test_import.py
+++ b/backend/corpora/gallica/tests/test_import.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+import time
+
 import requests
 
-from conftest import mock_response
+from conftest import mock_response, mock_sleep
 from addcorpus.python_corpora.load_corpus import load_corpus_definition
 
 
@@ -21,6 +23,7 @@ target_documents = [
 
 def test_gallica_import(monkeypatch, gallica_corpus_settings):
     monkeypatch.setattr(requests, "get", mock_response)
+    monkeypatch.setattr(time, "sleep", mock_sleep)
     corpus_def = load_corpus_definition("figaro")
     sources = corpus_def.sources(
         start=datetime(year=1930, month=1, day=1),


### PR DESCRIPTION
There is a throttle on the Gallica API, which caused periodical crashes & necessity for manual restarts. This branch automates those restarts, and it now seems to run smoothly (albeit very slowly) over the remaining Figaro data.