### PR TITLE
remove user survey link

### DIFF
--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -1,9 +1,3 @@
-<div class="message">
-    <p class="message-body has-text-right">
-        Participate in the <a href="https://survey.uu.nl/jfe/form/SV_1HRZ0Vel6gjVXJs">I-analyzer user survey!</a>
-    </p>
-</div>
-
 <div [class.is-loading]="isLoading | async">
     <ia-corpus-selection [items]="items"></ia-corpus-selection>
 </div>


### PR DESCRIPTION
The link to the user survey has been up for a while now (#1682), so I think we can remove it with the next release.