### PR TITLE
utilise session cleanup for test indices

### DIFF
--- a/backend/addcorpus/python_corpora/tests/test_times_source.py
+++ b/backend/addcorpus/python_corpora/tests/test_times_source.py
@@ -12,7 +12,7 @@ def times_test_settings(settings):
         'times': join(settings.BASE_DIR, 'corpora/times/times.py')
     }
     settings.TIMES_DATA = join(settings.BASE_DIR, 'addcorpus/python_corpora/tests')
-    settings.TIMES_ES_INDEX = 'times-test'
+    settings.TIMES_ES_INDEX = 'test-times'
 
 
 

--- a/backend/es/conftest.py
+++ b/backend/es/conftest.py
@@ -46,20 +46,20 @@ def es_ner_search_client(es_client, basic_mock_corpus, basic_corpus_public, inde
 
 
 @pytest.fixture()
-def es_index_client(es_client, mock_corpus):
+def es_index_client(es_client, mock_corpus, test_index_cleanup):
     """
     Returns an elastic search client for the mock corpus.
-    After tests, removes any indices created for the mock corpus.
+    After each test, removes any indices created for the mock corpus.
     """
 
     yield es_client
     # delete indices when done
-    indices = es_client.indices.get(index='times-test*')
+    indices = es_client.indices.get(index='test-times*')
     for index in indices.keys():
         es_client.indices.delete(index=index)
 
 @pytest.fixture()
-def es_alias_client(db, es_server, es_client, mock_corpus):
+def es_alias_client(db, es_server, es_client, mock_corpus, test_index_cleanup):
     """
     Create multiple indices with version numbers for the mock corpus in elasticsearch.
     Returns an elastic search client for the mock corpus.
@@ -67,7 +67,7 @@ def es_alias_client(db, es_server, es_client, mock_corpus):
     # add data from mock corpus
     corpus = Corpus.objects.get(name=mock_corpus)
     index = Index.objects.create(
-        name='times-test-1',
+        name='test-times-1',
         server=es_server,
     )
     job = IndexJob.objects.create(
@@ -79,12 +79,12 @@ def es_alias_client(db, es_server, es_client, mock_corpus):
         delete_existing=True,
     )
     es_index.create(create_task)
-    es_client.indices.create(index='times-test-2')
-    es_client.indices.create(index='times-test-bla-3')
+    es_client.indices.create(index='test-times-2')
+    es_client.indices.create(index='test-times-bla-3')
 
     yield es_client
     # delete index when done
-    indices = es_client.indices.get(index='times-test*')
+    indices = es_client.indices.get(index='test-times*')
     for index in indices.keys():
         es_client.indices.delete(index=index)
 

--- a/backend/es/tests/test_alias.py
+++ b/backend/es/tests/test_alias.py
@@ -5,30 +5,30 @@ from es.es_index import perform_indexing
 
 def test_alias(db, es_alias_client):
     corpus = Corpus.objects.get(name='times')
-    assert corpus.configuration.es_index == 'times-test'
+    assert corpus.configuration.es_index == 'test-times'
     job = create_alias_job(corpus)
     perform_indexing(job)
     res = es_alias_client.indices.get_alias(name=corpus.configuration.es_index)
-    assert res.get('times-test-2') is not None
+    assert res.get('test-times-2') is not None
 
 
 def test_alias_with_clean(es_alias_client):
     corpus = Corpus.objects.get(name='times')
     indices = es_alias_client.indices.get(
         index='{}-*'.format(corpus.configuration.es_index))
-    assert 'times-test-1' in list(indices.keys())
+    assert 'test-times-1' in list(indices.keys())
     job = create_alias_job(corpus, True)
     perform_indexing(job)
     indices = es_alias_client.indices.get(
         index='{}-*'.format(corpus.configuration.es_index))
-    assert 'times-test-1' not in list(indices.keys())
+    assert 'test-times-1' not in list(indices.keys())
 
 
 def test_highest_version_number(es_alias_client):
     corpus = Corpus.objects.get(name='times')
     indices = es_alias_client.indices.get(
         index='{}-*'.format(corpus.configuration.es_index))
-    current_index = 'times-test'
+    current_index = 'test-times'
     num = get_highest_version_number(indices, current_index)
     assert num == 2
     current_index = "fantasy-index-name"

--- a/backend/es/tests/test_es_index.py
+++ b/backend/es/tests/test_es_index.py
@@ -13,7 +13,7 @@ def mock_client(es_index_client):
     return es_index_client
 
 
-@pytest.mark.parametrize("prod, name, shards", [(True, "times-test-1", '5'), (False, "times-test", '1')])
+@pytest.mark.parametrize("prod, name, shards", [(True, "test-times-1", '5'), (False, "test-times", '1')])
 def test_prod_flag(mock_corpus, es_index_client, corpus_definition, prod, name, shards):
     corpus = Corpus.objects.get(name=mock_corpus)
     job = create_indexing_job(
@@ -36,7 +36,7 @@ def test_mappings_only_flag(mock_corpus, es_index_client, corpus_definition, map
     )
     perform_indexing(job)
     sleep(1)
-    res = es_index_client.count(index='times-test*')
+    res = es_index_client.count(index='test-times*')
     assert res.get('count') == expected
 
 
@@ -47,7 +47,7 @@ def test_add_clear(db, mock_corpus, es_index_client):
         mappings_only=True, add=False, clear=False, prod=False, rollover=False,
     )
     perform_indexing(job)
-    res = es_index_client.count(index='times-test*')
+    res = es_index_client.count(index='test-times*')
     assert res.get('count') == 0
     job = create_indexing_job(
         corpus, START, END,
@@ -55,14 +55,14 @@ def test_add_clear(db, mock_corpus, es_index_client):
     )
     perform_indexing(job)
     sleep(1)
-    res = es_index_client.count(index='times-test*')
+    res = es_index_client.count(index='test-times*')
     assert res.get('count') == 2
     job = create_indexing_job(
         corpus, START, END,
         mappings_only=True, add=False, clear=True, prod=False, rollover=False,
     )
     perform_indexing(job)
-    res = es_index_client.count(index='times-test*')
+    res = es_index_client.count(index='test-times*')
     assert res.get('count') == 0
 
 
@@ -88,4 +88,4 @@ def test_indexing_with_version(mock_corpus, corpus_definition, es_index_client):
         rollover=True,
     )
     perform_indexing(job)
-    assert es_index_client.indices.exists(index="times-test-1") == True
+    assert es_index_client.indices.exists(index="test-times-1") == True

--- a/backend/ianalyzer/settings_test.py
+++ b/backend/ianalyzer/settings_test.py
@@ -15,7 +15,7 @@ CORPORA = {
 }
 
 TIMES_DATA = os.path.join(BASE_DIR, 'addcorpus', 'python_corpora', 'tests')
-TIMES_ES_INDEX = 'times-test'
+TIMES_ES_INDEX = 'test-times'
 
 UBLAD_DATA = '' # necessary to make ublad test not fail
 


### PR DESCRIPTION
Tiny change to the names used for indices created in unit tests.

The affected indices are now caught by the `test_index_cleanup` fixture, which removes test indices at the start and end of each session. This fixes a problem where tests may fail because the previous session was not completed (and lingering indices are messing up the test).