### PR TITLE
Feature/reorder fields

### DIFF
--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -174,8 +174,10 @@ class CorpusJSONDefinitionSerializer(serializers.ModelSerializer):
 
         corpus = Corpus.objects.create(**definition_data)
         configuration = CorpusConfiguration.objects.create(corpus=corpus, **configuration_data)
-        for field_data in fields_data:
-            Field.objects.create(corpus_configuration=configuration, **field_data)
+        for i, field_data in enumerate(fields_data):
+            Field.objects.create(
+                corpus_configuration=configuration, position=i, **field_data
+            )
 
         if validated_data.get('active') == True:
             corpus.active = True
@@ -198,7 +200,7 @@ class CorpusJSONDefinitionSerializer(serializers.ModelSerializer):
             setattr(configuration, attr, configuration_data[attr])
         configuration.save()
 
-        for field_data in fields_data:
+        for i, field_data in enumerate(fields_data):
             try:
                 field = Field.objects.get(
                     corpus_configuration=configuration, name=field_data['name'])
@@ -207,6 +209,7 @@ class CorpusJSONDefinitionSerializer(serializers.ModelSerializer):
                               name=field_data['name'])
             for attr in field_data:
                 setattr(field, attr, field_data[attr])
+            field.position = i
             field.save()
 
         configuration.fields.exclude(name__in=(f['name'] for f in fields_data)).delete()

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -79,14 +79,16 @@
                 <div class="control">
                     <button class="button" type="button" aria-label="move up"
                         iaBalloon="move field up"
-                        [disabled]="isFirst">
+                        [disabled]="isFirst"
+                        (click)="moveField(i, field, -1)">
                         <fa-icon [icon]="directionIcons.up" aria-hidden="true" />
                     </button>
                 </div>
                 <div class="control">
                     <button class="button" type="button" aria-label="move down"
                         iaBalloon="move field down"
-                        [disabled]="isLast">
+                        [disabled]="isLast"
+                        (click)="moveField(i, field, +1)">
                         <fa-icon [icon]="directionIcons.down" aria-hidden="true" />
                     </button>
                 </div>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -4,7 +4,7 @@
         <div class="box"
             *ngFor="let field of fields.controls;
                 index as i; first as isFirst; last as isLast;
-                trackBy: fieldControlTrackBy"
+                trackBy: fieldControlName"
             [formGroupName]="i">
             <div class="field">
                 <label class="label" for="column_name">Column name</label>
@@ -77,8 +77,13 @@
 
             <div class="field is-grouped" style="justify-content: end;">
                 <div class="control">
+                    <!-- the first "move down" and the last "move up" button are disabled;
+                        this is done with CSS/ARIA/javascript rather than the "disabled"
+                        attribute, so the control can stay focused when the user moves
+                        the field to the first/last position.
+                    -->
                     <button class="button" type="button" aria-label="move up"
-                        id="moveup-{{fieldControlTrackBy(i, field)}}"
+                        [id]="moveControlID(i, field, -1)"
                         iaBalloon="move field up"
                         [attr.aria-disabled]="isFirst"
                         [class.is-disabled]="isFirst"
@@ -88,7 +93,7 @@
                 </div>
                 <div class="control">
                     <button class="button" type="button" aria-label="move down"
-                        id="movedown-{{fieldControlTrackBy(i, field)}}"
+                        [id]="moveControlID(i, field, +1)"
                         iaBalloon="move field down"
                         [attr.aria-disabled]="isLast"
                         [class.is-disabled]="isLast"

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -1,7 +1,9 @@
 <h1 class="title">Fields</h1>
 <form class="container is-readable" [formGroup]="fieldsForm" (ngSubmit)="onSubmit()">
     <ng-container formArrayName="fields">
-        <div class="box" *ngFor="let field of fields.controls; let i=index" [formGroupName]="i">
+        <div class="box"
+            *ngFor="let field of fields.controls; let i=index; first as isFirst; last as isLast"
+            [formGroupName]="i">
             <div class="field">
                 <label class="label" for="column_name">Column name</label>
                 <div class="control">
@@ -71,6 +73,22 @@
                 </div>
             </div>
 
+            <div class="field is-grouped" style="justify-content: end;">
+                <div class="control">
+                    <button class="button" type="button" aria-label="move up"
+                        iaBalloon="move field up"
+                        [disabled]="isFirst">
+                        <fa-icon [icon]="directionIcons.up" aria-hidden="true" />
+                    </button>
+                </div>
+                <div class="control">
+                    <button class="button" type="button" aria-label="move down"
+                        iaBalloon="move field down"
+                        [disabled]="isLast">
+                        <fa-icon [icon]="directionIcons.down" aria-hidden="true" />
+                    </button>
+                </div>
+            </div>
         </div>
     </ng-container>
 
@@ -78,7 +96,7 @@
 
     <div class="field">
         <p class="control">
-            <button class="button is-primary">Save changes</button>
+            <button class="button is-primary" type="submit">Save changes</button>
         </p>
     </div>
 </form>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -78,17 +78,21 @@
             <div class="field is-grouped" style="justify-content: end;">
                 <div class="control">
                     <button class="button" type="button" aria-label="move up"
+                        id="moveup-{{fieldControlTrackBy(i, field)}}"
                         iaBalloon="move field up"
-                        [disabled]="isFirst"
-                        (click)="moveField(i, field, -1)">
+                        [attr.aria-disabled]="isFirst"
+                        [class.is-disabled]="isFirst"
+                        (click)="isFirst || moveField(i, field, -1)">
                         <fa-icon [icon]="directionIcons.up" aria-hidden="true" />
                     </button>
                 </div>
                 <div class="control">
                     <button class="button" type="button" aria-label="move down"
+                        id="movedown-{{fieldControlTrackBy(i, field)}}"
                         iaBalloon="move field down"
-                        [disabled]="isLast"
-                        (click)="moveField(i, field, +1)">
+                        [attr.aria-disabled]="isLast"
+                        [class.is-disabled]="isLast"
+                        (click)="isLast || moveField(i, field, +1)">
                         <fa-icon [icon]="directionIcons.down" aria-hidden="true" />
                     </button>
                 </div>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -2,7 +2,9 @@
 <form class="container is-readable" [formGroup]="fieldsForm" (ngSubmit)="onSubmit()">
     <ng-container formArrayName="fields">
         <div class="box"
-            *ngFor="let field of fields.controls; let i=index; first as isFirst; last as isLast"
+            *ngFor="let field of fields.controls;
+                index as i; first as isFirst; last as isLast;
+                trackBy: fieldControlTrackBy"
             [formGroupName]="i">
             <div class="field">
                 <label class="label" for="column_name">Column name</label>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -116,12 +116,16 @@ export class FieldFormComponent {
         this.corpus.definition.fields =
             newFields as CorpusDefinition['definition']['fields'];
         this.corpus.save().subscribe({
-            next: console.log,
             error: console.error,
         });
     }
 
     fieldControlTrackBy(_index: number, field: FormControl) {
         return field.get('extract').get('column').value as string;
+    }
+
+    moveField(index: number, field: FormControl, delta: number) {
+        this.fields.removeAt(index);
+        this.fields.insert(index + delta, field);
     }
 }

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -9,6 +9,7 @@ import { Subject, takeUntil } from 'rxjs';
 import * as _ from 'lodash';
 
 import { ISO6393Languages } from '../constants';
+import { actionIcons, directionIcons } from '@shared/icons';
 
 @Component({
     selector: 'ia-field-form',
@@ -49,6 +50,9 @@ export class FieldFormComponent {
     ];
 
     languageOptions = ISO6393Languages;
+
+    actionIcons = actionIcons;
+    directionIcons = directionIcons;
 
     constructor() {}
 

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, Input, SimpleChanges } from '@angular/core';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import {
     APICorpusDefinitionField,
@@ -54,7 +54,9 @@ export class FieldFormComponent {
     actionIcons = actionIcons;
     directionIcons = directionIcons;
 
-    constructor() {}
+    constructor(
+        private el: ElementRef<HTMLElement>,
+    ) {}
 
     get fields(): FormArray {
         return this.fieldsForm.get('fields') as FormArray;
@@ -124,8 +126,21 @@ export class FieldFormComponent {
         return field.get('extract').get('column').value as string;
     }
 
-    moveField(index: number, field: FormControl, delta: number) {
+    moveField(index: number, field: FormControl, delta: number): void {
         this.fields.removeAt(index);
         this.fields.insert(index + delta, field);
+
+        setTimeout(() => this.focusOnMoveControl(index, field, delta));
+    }
+
+    focusOnMoveControl(index: number, field: FormControl, delta: number): void {
+        const fieldID = this.fieldControlTrackBy(index + delta, field);
+        const label = delta > 0 ? 'movedown' : 'moveup';
+        const selector = '#' + label + '-' + fieldID;
+        const button = this.el.nativeElement.querySelector<HTMLButtonElement>(
+            selector
+        );
+        button.focus();
+
     }
 }

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -122,7 +122,11 @@ export class FieldFormComponent {
         });
     }
 
-    fieldControlTrackBy(_index: number, field: FormControl) {
+    /** identifier for a field control
+     *
+     * includes the index as an argument so this can be used as a TrackByFunction
+     */
+    fieldControlName(index: number, field: FormControl) {
         return field.get('extract').get('column').value as string;
     }
 
@@ -130,17 +134,18 @@ export class FieldFormComponent {
         this.fields.removeAt(index);
         this.fields.insert(index + delta, field);
 
+        // after change detection, restore focus to the button
         setTimeout(() => this.focusOnMoveControl(index, field, delta));
     }
 
-    focusOnMoveControl(index: number, field: FormControl, delta: number): void {
-        const fieldID = this.fieldControlTrackBy(index + delta, field);
+    moveControlID(index: number, field: FormControl, delta: number): string {
         const label = delta > 0 ? 'movedown' : 'moveup';
-        const selector = '#' + label + '-' + fieldID;
-        const button = this.el.nativeElement.querySelector<HTMLButtonElement>(
-            selector
-        );
-        button.focus();
+        return label + '-' + this.fieldControlName(index, field);
+    }
 
+    focusOnMoveControl(index: number, field: FormControl, delta: number): void {
+        const selector = '#' + this.moveControlID(index, field, delta);
+        const button = this.el.nativeElement.querySelector<HTMLButtonElement>(selector);
+        button.focus();
     }
 }

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -120,4 +120,8 @@ export class FieldFormComponent {
             error: console.error,
         });
     }
+
+    fieldControlTrackBy(_index: number, field: FormControl) {
+        return field.get('extract').get('column').value as string;
+    }
 }

--- a/frontend/src/app/shared/icons.ts
+++ b/frontend/src/app/shared/icons.ts
@@ -58,6 +58,8 @@ import {
     faUser,
     faArrowsUpDown,
     faArrowRightArrowLeft,
+    faArrowUp,
+    faArrowDown,
 } from '@fortawesome/free-solid-svg-icons';
 
 type IconDefinition = SolidIconDefinition | RegularIconDefinition;
@@ -81,6 +83,13 @@ export const navIcons: Icons = {
     admin: faCogs,
     downloads: faDownload,
     tags: faTags,
+};
+
+export const directionIcons: Icons = {
+    up: faArrowUp,
+    down: faArrowDown,
+    left: faArrowLeft,
+    right: faArrowRight,
 };
 
 export const actionIcons: Icons = {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -99,3 +99,7 @@ a.dropdown-item[disabled] {
 .entity-miscellaneous {
     @include mark-entity($entity-miscellaneous);
 }
+
+.is-disabled {
+    @extend [disabled];
+}


### PR DESCRIPTION
Allows users to change the order of fields in a corpus (part of #1736)

Screenshot:

![screenshot of I-analyzer. Shows corpus form with up/down buttons below each field.](https://github.com/user-attachments/assets/906d5b63-90b8-418a-b936-6cec1db3cfad)
