### PR TITLE
Feature/dropdown roles

### DIFF
--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -18,9 +18,9 @@
     </div>
 
     <div class="field">
-        <label class="label" for="category">Category</label>
+        <label class="label" for="category" id="label-category">Category</label>
         <div class="control">
-            <ia-dropdown formControlName="category">
+            <ia-dropdown formControlName="category" labelledBy="label-category">
                 <span iaDropdownLabel>{{currentCategoryLabel}}</span>
                 <div iaDropdownMenu>
                     <a *ngFor="let category of categories"

--- a/frontend/src/app/corpus-selection/corpus-filter/corpus-filter.component.html
+++ b/frontend/src/app/corpus-selection/corpus-filter/corpus-filter.component.html
@@ -4,7 +4,7 @@
             <label class="label" id="label-language">Language</label>
             <div class="control">
                 <ia-dropdown name="language" [formControl]="form.controls.language"
-                    ariaLabelledBy="label-language">
+                    labelledBy="label-language">
                     <span iaDropdownLabel>{{form.controls.language.value || 'Any'}}</span>
                     <div iaDropdownMenu>
                         <a iaDropdownItem [value]="null">Any</a>
@@ -20,7 +20,7 @@
             <label class="label" id="label-category">Type of data</label>
             <div class="control">
                 <ia-dropdown name="category" [formControl]="form.controls.category"
-                    ariaLabelledBy="label-category">
+                    labelledBy="label-category">
                     <span iaDropdownLabel>{{form.controls.category.value || 'Any'}}</span>
                     <div iaDropdownMenu>
                         <a iaDropdownItem [value]="null">Any</a>

--- a/frontend/src/app/corpus-selection/corpus-filter/corpus-filter.component.html
+++ b/frontend/src/app/corpus-selection/corpus-filter/corpus-filter.component.html
@@ -1,9 +1,10 @@
 <form [formGroup]="form">
     <div class="columns">
         <div class="column field">
-            <label class="label">Language</label>
+            <label class="label" id="label-language">Language</label>
             <div class="control">
-                <ia-dropdown name="language" [formControl]="form.controls.language">
+                <ia-dropdown name="language" [formControl]="form.controls.language"
+                    ariaLabelledBy="label-language">
                     <span iaDropdownLabel>{{form.controls.language.value || 'Any'}}</span>
                     <div iaDropdownMenu>
                         <a iaDropdownItem [value]="null">Any</a>
@@ -16,9 +17,10 @@
             </div>
         </div>
         <div class="column field">
-            <label class="label">Type of data</label>
+            <label class="label" id="label-category">Type of data</label>
             <div class="control">
-                <ia-dropdown name="category" [formControl]="form.controls.category">
+                <ia-dropdown name="category" [formControl]="form.controls.category"
+                    ariaLabelledBy="label-category">
                     <span iaDropdownLabel>{{form.controls.category.value || 'Any'}}</span>
                     <div iaDropdownMenu>
                         <a iaDropdownItem [value]="null">Any</a>

--- a/frontend/src/app/document/document-view/document-view.component.scss
+++ b/frontend/src/app/document/document-view/document-view.component.scss
@@ -1,10 +1,4 @@
-@import "../../../_utilities";
-
 table {
     word-wrap:break-word;
     table-layout: fixed;
-
-    ::ng-deep a {
-        color: $primary;
-    }
 }

--- a/frontend/src/app/download/download.component.html
+++ b/frontend/src/app/download/download.component.html
@@ -30,10 +30,10 @@
         </div>
 
         <div class="field">
-            <p class="label">
+            <label class="label" id="sort-by-label">
                 Sort results
-            </p>
-            <ia-search-sorting [pageResults]="resultsConfig"></ia-search-sorting>
+            </label>
+            <ia-search-sorting [pageResults]="resultsConfig" labelledBy="sort-by-label" />
         </div>
 
         <!-- TODO: show this option when query-in-context download is fixed -->

--- a/frontend/src/app/search/results-sort/search-sorting.component.html
+++ b/frontend/src/app/search/results-sort/search-sorting.component.html
@@ -1,5 +1,6 @@
 <div class="control">
-    <ia-dropdown (onChange)="changeField($event)" [value]="sortField">
+    <ia-dropdown (onChange)="changeField($event)" [value]="sortField"
+        [labelledBy]="labelledBy">
         <span iaDropdownLabel>{{ sortField?.displayName || 'Relevance' }}</span>
         <div iaDropdownMenu>
             <a iaDropdownItem [value]="undefined">Relevance</a>

--- a/frontend/src/app/search/results-sort/search-sorting.component.ts
+++ b/frontend/src/app/search/results-sort/search-sorting.component.ts
@@ -16,6 +16,7 @@ const defaultValueType = 'alpha';
 export class SearchSortingComponent {
     @HostBinding('class') classes = 'field has-addons';
     @Input() pageResults: PageResults;
+    @Input() labelledBy: string;
 
     public valueType: 'alpha' | 'numeric' = defaultValueType;
     public showFields = false;

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -16,8 +16,8 @@
         <div class="level">
             <div class="level-left has-text-centered">
                 <div>
-                    <p class="heading">Sort By</p>
-                    <ia-search-sorting [pageResults]="pageResults"></ia-search-sorting>
+                    <label class="heading" id="sort-by-label">Sort By</label>
+                    <ia-search-sorting [pageResults]="pageResults" labelledBy="sort-by-label" />
                 </div>
             </div>
             <div class="level-right has-text-centered" *ngIf="page.total > resultsPerPage" >

--- a/frontend/src/app/shared/dropdown/README.md
+++ b/frontend/src/app/shared/dropdown/README.md
@@ -1,10 +1,12 @@
 # Dropdown component
 
+The dropdown component is a [combobox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role). It has a [listbox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role) popup and allows the user to select a single item from a list.
+
 Typical usage looks like this:
 
 ```html
-<label id="lucky-number-id">Lucky number</label>
-<ia-dropdown (onChange)="selection = $event" labelledBy="lucky-number-id">
+<label id="lucky-number-label">Lucky number</label>
+<ia-dropdown (onChange)="selection = $event" labelledBy="lucky-number-label">
     <span iaDropdownLabel>{{selection}}</span>
     <div iaDropdownMenu>
         <a iaDropdownItem [value]="3">
@@ -40,7 +42,7 @@ You can insert other content into the dropdown menu:
 </ia-dropdown>
 ```
 
-See the [bulma dropdown documentation](https://bulma.io/documentation/components/dropdown/) for documentation on available CSS classes.
+However, be aware that a [listbox]((https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role)) has limited options for the semantics of its children. Also, because the popup is normally hidden, unfocusable content (such as explanations) may be missed by users who navigate the page with a screen reader.
 
 ## API
 
@@ -55,4 +57,5 @@ The dropdown component supports:
 - `[disabled]` input: if `true`, this disables the entire menu.
 - `[labelledBy]` input: sets the ID of the element labelling the dropdown. This is required to make the dropdown accessible.
 - `(onChanges)` output: emits all changes to the selected value, including when it is set through input. If you only want to listen to UI events, use `(onSelect)` on the individual items instead.
+- `[formControl]`: register a control in a [reactive form](https://angular.dev/guide/forms/reactive-forms).
 

--- a/frontend/src/app/shared/dropdown/README.md
+++ b/frontend/src/app/shared/dropdown/README.md
@@ -3,7 +3,8 @@
 Typical usage looks like this:
 
 ```html
-<ia-dropdown (onChange)="selection = $event">
+<label id="lucky-number-id">Lucky number</label>
+<ia-dropdown (onChange)="selection = $event" labelledBy="lucky-number-id">
     <span iaDropdownLabel>{{selection}}</span>
     <div iaDropdownMenu>
         <a iaDropdownItem [value]="3">
@@ -21,7 +22,8 @@ Typical usage looks like this:
 You can insert other content into the dropdown menu:
 
 ```html
-<ia-dropdown (onChange)="value = $event">
+<label id="lucky-number-id">Lucky number</label>
+<ia-dropdown (onChange)="value = $event" labelledBy="lucky-number-id">
     <span iaDropdownLabel>{{value}}</span>
     <div iaDropdownMenu>
         <a iaDropdownItem [value]="3">
@@ -51,5 +53,6 @@ The dropdown component supports:
 
 - `[value]` input: this sets the selected value in the menu - use this to set the value from the parent component.
 - `[disabled]` input: if `true`, this disables the entire menu.
+- `[labelledBy]` input: sets the ID of the element labelling the dropdown. This is required to make the dropdown accessible.
 - `(onChanges)` output: emits all changes to the selected value, including when it is set through input. If you only want to listen to UI events, use `(onSelect)` on the individual items instead.
 

--- a/frontend/src/app/shared/dropdown/dropdown-item.directive.ts
+++ b/frontend/src/app/shared/dropdown/dropdown-item.directive.ts
@@ -8,7 +8,7 @@ import * as _ from 'lodash';
 })
 export class DropdownItemDirective {
     @HostBinding('class') class = 'dropdown-item';
-    @HostBinding('role') role = 'menuitem';
+    @HostBinding('role') role = 'option';
     @HostBinding('attr.tabIndex') tabIndex = 0;
 
     @Input() value;
@@ -38,6 +38,7 @@ export class DropdownItemDirective {
     }
 
     @HostBinding('class.is-active')
+    @HostBinding('attr.aria-selected')
     get isActive(): boolean {
         return _.isEqual(this.dropdownService.selection$.value, this.value);
     }

--- a/frontend/src/app/shared/dropdown/dropdown.component.html
+++ b/frontend/src/app/shared/dropdown/dropdown.component.html
@@ -4,6 +4,7 @@
         role="combobox"
         [attr.aria-controls]="menuID"
         [attr.aria-expanded]="open$ | async"
+        [attr.aria-labelledby]="ariaLabelledBy"
         [id]="triggerID"
         [disabled]="disabled"
         (click)="toggleDropdown()"

--- a/frontend/src/app/shared/dropdown/dropdown.component.html
+++ b/frontend/src/app/shared/dropdown/dropdown.component.html
@@ -4,7 +4,7 @@
         role="combobox"
         [attr.aria-controls]="menuID"
         [attr.aria-expanded]="open$ | async"
-        [attr.aria-labelledby]="ariaLabelledBy"
+        [attr.aria-labelledby]="labelledBy"
         [id]="triggerID"
         [disabled]="disabled"
         (click)="toggleDropdown()"

--- a/frontend/src/app/shared/dropdown/dropdown.component.html
+++ b/frontend/src/app/shared/dropdown/dropdown.component.html
@@ -1,6 +1,10 @@
 <div class="dropdown-trigger">
-    <button class="button" aria-haspopup="true"
-        aria-controls="dropdownMenu" id="dropdownTrigger"
+    <button class="button"
+        aria-haspopup="listbox"
+        role="combobox"
+        [attr.aria-controls]="menuID"
+        [attr.aria-expanded]="open$ | async"
+        [id]="triggerID"
         [disabled]="disabled"
         (click)="toggleDropdown()"
         (keydown.arrowdown)="focusOnFirstItem($event)"
@@ -13,8 +17,10 @@
         </span>
     </button>
 </div>
-<div class="dropdown-menu" role="menu"
-    id="dropdownTrigger" aria-labelledby="dropdownMenu">
+<div class="dropdown-menu"
+    role="listbox"
+    [id]="menuID"
+    [attr.aria-labelledby]="triggerID">
     <div class="dropdown-content">
         <ng-content select="[iaDropdownMenu]"></ng-content>
     </div>

--- a/frontend/src/app/shared/dropdown/dropdown.component.spec.ts
+++ b/frontend/src/app/shared/dropdown/dropdown.component.spec.ts
@@ -51,7 +51,7 @@ describe('DropdownComponent', () => {
     it('should render the label', async () => {
         await fixture.whenStable();
 
-        const trigger = fixture.debugElement.query(By.css('#dropdownTrigger')).nativeElement;
+        const trigger = fixture.debugElement.query(By.css('.dropdown-trigger > button')).nativeElement;
 
         expect(trigger.innerHTML).toContain('Select option');
 
@@ -71,7 +71,7 @@ describe('DropdownComponent', () => {
 
         expect(dropdown.classes['is-active']).toBeFalsy();
 
-        const trigger = dropdown.query(By.css('#dropdownTrigger'));
+        const trigger = dropdown.query(By.css('.dropdown-trigger > button'));
         trigger.triggerEventHandler('click', undefined);
 
         tick();

--- a/frontend/src/app/shared/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/dropdown/dropdown.component.ts
@@ -39,6 +39,7 @@ export class DropdownComponent<T> implements OnChanges, AfterViewInit, OnDestroy
 
     @Input() value: any;
     @Input() disabled: boolean;
+    @Input() ariaLabelledBy: string;
 
     @Output()
     public onChange = new EventEmitter<T>();

--- a/frontend/src/app/shared/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/dropdown/dropdown.component.ts
@@ -20,6 +20,8 @@ import { actionIcons } from '../icons';
 import { DropdownService } from './dropdown.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
+let nextID = 0;
+
 @Component({
     selector: 'ia-dropdown',
     templateUrl: './dropdown.component.html',
@@ -45,6 +47,10 @@ export class DropdownComponent<T> implements OnChanges, AfterViewInit, OnDestroy
 
     actionIcons = actionIcons;
 
+
+    id = nextID++;
+    open$ = this.dropdownService.open$;
+
     private blur$ = new Subject<void>();
     private destroy$ = new Subject<void>();
     private onChangeSubscription?: Subscription;
@@ -63,6 +69,14 @@ export class DropdownComponent<T> implements OnChanges, AfterViewInit, OnDestroy
     @HostBinding('class.is-active')
     get isActive(): boolean {
         return this.dropdownService.open$.value;
+    }
+
+    get triggerID(): string {
+        return `dropdown-trigger-${this.id}`;
+    }
+
+    get menuID(): string {
+        return `dropdown-menu-${this.id}`;
     }
 
     @HostListener('document:click', ['$event'])
@@ -122,9 +136,8 @@ export class DropdownComponent<T> implements OnChanges, AfterViewInit, OnDestroy
 
     focusOnFirstItem(event: KeyboardEvent) {
         event.preventDefault();
-        if (this.dropdownService.open$.value) {
-            this.dropdownService.focusShift$.next(1);
-        }
+        this.dropdownService.open$.next(true);
+        this.dropdownService.focusShift$.next(1);
     }
 
 }

--- a/frontend/src/app/shared/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/dropdown/dropdown.component.ts
@@ -39,7 +39,9 @@ export class DropdownComponent<T> implements OnChanges, AfterViewInit, OnDestroy
 
     @Input() value: any;
     @Input() disabled: boolean;
-    @Input() ariaLabelledBy: string;
+
+    /** ID of the element labelling the dropdown */
+    @Input() labelledBy: string;
 
     @Output()
     public onChange = new EventEmitter<T>();

--- a/frontend/src/app/shared/dropdown/dropdown.component.ts
+++ b/frontend/src/app/shared/dropdown/dropdown.component.ts
@@ -138,7 +138,8 @@ export class DropdownComponent<T> implements OnChanges, AfterViewInit, OnDestroy
     focusOnFirstItem(event: KeyboardEvent) {
         event.preventDefault();
         this.dropdownService.open$.next(true);
-        this.dropdownService.focusShift$.next(1);
+        // focus on the first item - use setTimeout to wait until the menu is opened
+        setTimeout(() => this.dropdownService.focusShift$.next(1));
     }
 
 }

--- a/frontend/src/app/tag/document-tags/document-tags.component.html
+++ b/frontend/src/app/tag/document-tags/document-tags.component.html
@@ -14,7 +14,7 @@
 
     <div class="control">
         <ng-container *ngIf="showAddNew; else toggleAddNew">
-            <ia-tag-select [exclude]="tags" (selection)="addTag($event)" (cancel)="cancelAddNew()" />
+            <ia-tag-select [exclude]="tags" (selection)="addTag($event)" (cancel)="closeAddNew()" />
         </ng-container>
 
         <ng-template #toggleAddNew>

--- a/frontend/src/app/tag/document-tags/document-tags.component.html
+++ b/frontend/src/app/tag/document-tags/document-tags.component.html
@@ -14,13 +14,14 @@
 
     <div class="control">
         <ng-container *ngIf="showAddNew; else toggleAddNew">
-            <ia-tag-select [exclude]="tags" (selection)="addTag($event)" (cancel)="showAddNew = false"></ia-tag-select>
+            <ia-tag-select [exclude]="tags" (selection)="addTag($event)" (cancel)="cancelAddNew()" />
         </ng-container>
 
         <ng-template #toggleAddNew>
             <button class="button tag" aria-label="add a tag"
                 iaBalloon="add a tag" iaBalloonPosition="up"
-                (click)="showAddNew = true">
+                (click)="showAddNew = true"
+                #toggleAddNewButton>
                 <span class="icon"><fa-icon [icon]="actionIcons.add" aria-hidden="true"></fa-icon></span>
             </button>
         </ng-template>

--- a/frontend/src/app/tag/document-tags/document-tags.component.ts
+++ b/frontend/src/app/tag/document-tags/document-tags.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { FoundDocument, Tag } from '@models';
 import * as _ from 'lodash';
 import { formIcons, actionIcons } from '@shared/icons';
@@ -11,6 +11,8 @@ import { formIcons, actionIcons } from '@shared/icons';
 export class DocumentTagsComponent implements OnChanges {
     @Input() document: FoundDocument;
     @Input() tags: Tag[];
+
+    @ViewChild('toggleAddNewButton') toggleAddNewButton: ElementRef<HTMLButtonElement>;
 
     formIcons = formIcons;
     actionIcons = actionIcons;
@@ -31,5 +33,10 @@ export class DocumentTagsComponent implements OnChanges {
 
     removeTag(tag: Tag) {
         this.document.removeTag(tag);
+    }
+
+    cancelAddNew() {
+        this.showAddNew = false;
+        setTimeout(() => this.toggleAddNewButton.nativeElement.focus());
     }
 }

--- a/frontend/src/app/tag/document-tags/document-tags.component.ts
+++ b/frontend/src/app/tag/document-tags/document-tags.component.ts
@@ -29,13 +29,15 @@ export class DocumentTagsComponent implements OnChanges {
 
     addTag(tag: Tag) {
         this.document.addTag(tag);
+        this.closeAddNew();
     }
 
     removeTag(tag: Tag) {
         this.document.removeTag(tag);
+        this.closeAddNew();
     }
 
-    cancelAddNew() {
+    closeAddNew() {
         this.showAddNew = false;
         setTimeout(() => this.toggleAddNewButton.nativeElement.focus());
     }

--- a/frontend/src/app/tag/tag-select/tag-select.component.html
+++ b/frontend/src/app/tag/tag-select/tag-select.component.html
@@ -25,6 +25,7 @@
     </div>
     <div class="control"  *ngIf="createMode">
         <input type="text"
+            aria-label="new tag name"
             class="input is-small tag-input" placeholder="Enter tag name"
             name="tag-name"
             #newTagNameInput

--- a/frontend/src/app/tag/tag-select/tag-select.component.html
+++ b/frontend/src/app/tag/tag-select/tag-select.component.html
@@ -1,14 +1,21 @@
 <form class="field has-addons">
     <div class="control" *ngIf="!createMode">
         <ng-container *ngIf="filterTags(tags$ | async, exclude) as filteredTags">
-            <ia-dropdown (onChange)="selectedTag = $event" class="tag-dropdown">
-                <span iaDropdownLabel>{{selectedTag?.name || 'Assign a tag'}}</span>
+            <ia-dropdown (onChange)="selectedTag = $event" class="tag-dropdown"
+                labelledBy="select-tag-placeholder">
+                <span iaDropdownLabel>
+                    {{ selectedTag?.name }}
+                    <span [class.is-hidden]="selectedTag?.name !== null"
+                        id="select-tag-placeholder">
+                        Assign a tag
+                    </span>
+                </span>
                 <div iaDropdownMenu>
                     <a *ngFor="let tag of filteredTags"
                         iaDropdownItem [value]="tag">
                         {{tag.name}}
                     </a>
-                    <a iaDropdownItem (onSelect)="toggleCreate()">
+                    <a iaDropdownItem (onSelect)="toggleCreate()" [value]="null">
                         <span class="icon"><fa-icon [icon]="actionIcons.add"></fa-icon></span>
                         <span>Create a new tag</span>
                     </a>

--- a/frontend/src/app/tag/tag-select/tag-select.component.html
+++ b/frontend/src/app/tag/tag-select/tag-select.component.html
@@ -27,6 +27,7 @@
         <input type="text"
             class="input is-small tag-input" placeholder="Enter tag name"
             name="tag-name"
+            #newTagNameInput
             [(ngModel)]="newTagName">
     </div>
     <div class="control">

--- a/frontend/src/app/tag/tag-select/tag-select.component.ts
+++ b/frontend/src/app/tag/tag-select/tag-select.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewInit,
     Component,
     ElementRef,
     EventEmitter,
@@ -13,18 +14,20 @@ import { Tag } from '@models';
 import { TagService } from '@services/tag.service';
 import { takeUntil } from 'rxjs/operators';
 import { actionIcons, formIcons } from '@shared/icons';
+import { DropdownComponent } from '@shared/dropdown/dropdown.component';
 
 @Component({
     selector: 'ia-tag-select',
     templateUrl: './tag-select.component.html',
     styleUrls: ['./tag-select.component.scss'],
 })
-export class TagSelectComponent implements OnDestroy {
+export class TagSelectComponent implements AfterViewInit, OnDestroy {
     @Input() exclude: Tag[];
     @Output() selection = new EventEmitter<Tag>();
     @Output() cancel = new EventEmitter<void>();
 
-    @ViewChild('tagSelect') tagSelect: ElementRef;
+    @ViewChild('newTagNameInput') newTagNameInput: ElementRef<HTMLInputElement>;
+    @ViewChild(DropdownComponent) dropdown: DropdownComponent<any>;
 
     tags$: Observable<Tag[]>;
     destroy$ = new Subject<void>();
@@ -39,6 +42,10 @@ export class TagSelectComponent implements OnDestroy {
 
     constructor(private tagService: TagService) {
         this.tags$ = this.tagService.tags$;
+    }
+
+    ngAfterViewInit() {
+        this.dropdown.trigger.nativeElement.focus();
     }
 
     filterTags(tags: Tag[], exclude?: Tag[]): Tag[] {
@@ -62,7 +69,8 @@ export class TagSelectComponent implements OnDestroy {
 
     toggleCreate(): void {
         this.selectedTag = undefined;
-        this.createMode = !this.createMode;
+        this.createMode = true;
+        setTimeout(() => this.newTagNameInput.nativeElement.focus());
     }
 
     ngOnDestroy(): void {

--- a/frontend/src/app/visualization/ngram/ngram.component.html
+++ b/frontend/src/app/visualization/ngram/ngram.component.html
@@ -4,11 +4,12 @@
         <div class="column is-one-third">
             <div class="field">
                 <label class="label" iaBalloon="search for bigrams (2 words) or trigrams (3 words)"
-                    iaBalloonPosition="up-left" iaBalloonLength="fit">
+                    iaBalloonPosition="up-left" iaBalloonLength="fit"
+                    id="label-size">
                     Length of n-gram
                 </label>
                 <div class="control">
-                    <ia-dropdown [value]="currentSizeOption"
+                    <ia-dropdown [value]="currentSizeOption" labelledBy="label-size"
                         (onChange)="onParameterChange('size', $event.value)">
                         <span iaDropdownLabel>{{currentSizeOption?.label}}</span>
                         <div iaDropdownMenu>
@@ -24,11 +25,12 @@
         <div class="column is-one-third">
             <div class="field">
                 <label class="label" iaBalloon="only search n-grams with the search term in the specified position"
-                iaBalloonPosition="up-left" iaBalloonLength="fit">
+                iaBalloonPosition="up-left" iaBalloonLength="fit"
+                id="label-positions">
                     Position of search term
                 </label>
                 <div class="control">
-                    <ia-dropdown [value]="currentPositionsOption"
+                    <ia-dropdown [value]="currentPositionsOption" labelledBy="label-positions"
                         (onChange)="onParameterChange('positions', $event.value)">
                         <span iaDropdownLabel>{{currentPositionsOption?.label}}</span>
                         <div iaDropdownMenu>
@@ -44,11 +46,12 @@
         <div class="column is-one-third">
             <div class="field">
                 <label class="label" iaBalloon="divide by the average frequency of the words in the n-gram; favours words that are otherwise rare"
-                iaBalloonPosition="up-left" iaBalloonLength="fit">
+                iaBalloonPosition="up-left" iaBalloonLength="fit"
+                id="label-freq-compensation">
                     Compensate for frequency
                 </label>
                 <div class="control">
-                    <ia-dropdown [value]="currentFreqCompensationOption"
+                    <ia-dropdown [value]="currentFreqCompensationOption" labelledBy="label-freq-compensation"
                         (onChange)="onParameterChange('freqCompensation', $event.value)">
                         <span iaDropdownLabel>{{currentFreqCompensationOption?.label}}</span>
                         <div iaDropdownMenu>
@@ -64,11 +67,12 @@
         <div class="column is-one-third" *ngIf="analysisOptions">
             <div class="field">
                 <label class="label" iaBalloon="pre-processing steps on the text, like removing stopwords or stemming"
-                    iaBalloonPosition="up-left" iaBalloonLength="fit">
+                    iaBalloonPosition="up-left" iaBalloonLength="fit"
+                    id="label-analysis">
                     Language processing
                 </label>
                 <div class="control">
-                    <ia-dropdown [value]="currentAnalysisOption"
+                    <ia-dropdown [value]="currentAnalysisOption" labelledBy="label-analysis"
                         (onChange)="onParameterChange('analysis', $event.value)">
                         <span iaDropdownLabel>{{currentAnalysisOption?.label}}</span>
                         <div iaDropdownMenu>
@@ -84,9 +88,12 @@
         <div class="column is-one-third">
             <div class="field">
                 <label class="label" iaBalloon="maximum number of documents analyzed per time interval"
-                iaBalloonPosition="up-left" iaBalloonLength="fit">Document limit</label>
+                    iaBalloonPosition="up-left" iaBalloonLength="fit"
+                    id="label-max-documents">
+                    Document limit
+                </label>
                 <div class="control">
-                    <ia-dropdown [value]="currentMaxDocumentsOption"
+                    <ia-dropdown [value]="currentMaxDocumentsOption" labelledBy="label-max-documents"
                         (onChange)="onParameterChange('maxDocuments', $event.value)">
                         <span iaDropdownLabel>{{currentMaxDocumentsOption?.label}}</span>
                         <div iaDropdownMenu>
@@ -102,9 +109,13 @@
         <div class="column is-one-third">
             <div class="field">
                 <label class="label" iaBalloon="the number of n-grams displayed in the results"
-                iaBalloonPosition="up-left" iaBalloonLength="fit">Number of n-grams</label>
+                    iaBalloonPosition="up-left" iaBalloonLength="fit"
+                    id="label-number-of-ngrams">
+                    Number of n-grams
+                </label>
                 <div class="control">
                     <ia-dropdown [value]="currentNumberOfNgramsOption"
+                        labelledBy="label-number-of-ngrams"
                         (onChange)="onParameterChange('numberOfNgrams', $event.value)">
                         <span iaDropdownLabel>{{currentNumberOfNgramsOption?.label}}</span>
                         <div iaDropdownMenu>
@@ -121,10 +132,12 @@
     <div class="column is-one-third" *ngIf="allDateFields && allDateFields.length > 1">
         <div class="field">
             <div class="control">
-                <label class="label" iaBalloon="field to use on the x-axis">
+                <label class="label" iaBalloon="field to use on the x-axis"
+                    id="label-date-field">
                     Compare frequencies by:
                 </label>
                 <ia-dropdown [value]="dateField"
+                    labelledBy="label-date-field"
                     (onChange)="onParameterChange('dateField', $event)">
                     <span iaDropdownLabel>{{dateField?.displayName}}</span>
                     <div iaDropdownMenu>

--- a/frontend/src/app/visualization/visualization-footer/palette-select/palette-select.component.html
+++ b/frontend/src/app/visualization/visualization-footer/palette-select/palette-select.component.html
@@ -1,12 +1,16 @@
-<ia-dropdown *ngIf="palettes" [value]="palette" (onChange)="palette = $event">
-    <span iaDropdownLabel class="icon">
-        <fa-icon [icon]="visualizationIcons.palette"></fa-icon>
+<ia-dropdown *ngIf="palettes" [value]="palette" (onChange)="palette = $event"
+    labelledBy="palette-icon">
+    <span iaDropdownLabel class="icon" id="palette-icon">
+        <fa-icon [icon]="visualizationIcons.palette" role="img"
+            aria-label="palette" />
     </span>
     <div iaDropdownMenu>
         <a *ngFor="let palette of palettes"
             iaDropdownItem [value]="palette">
-            <span class="icon" *ngFor="let color of palette" [style.color]="color">
-                <fa-icon [icon]="visualizationIcons.swatch"></fa-icon>
+            <span role="img" aria-label="colour swatches">
+                <span class="icon" *ngFor="let color of palette" [style.color]="color">
+                    <fa-icon [icon]="visualizationIcons.swatch"></fa-icon>
+                </span>
             </span>
         </a>
     </div>

--- a/frontend/src/app/visualization/visualization.component.html
+++ b/frontend/src/app/visualization/visualization.component.html
@@ -3,11 +3,12 @@
         <div class="columns">
             <div class="column">
                 <div class="field">
-                    <label class="label">
+                    <label class="label" id="label-visualization-type">
                         What do you want to visualise?
                     </label>
                     <div class="control">
-                        <ia-dropdown [value]="selector.activeOption$ | async">
+                        <ia-dropdown [value]="selector.activeOption$ | async"
+                            labelledBy="label-visualization-type">
                             <span iaDropdownLabel>{{(selector.activeOption$ | async).label}}</span>
                             <div iaDropdownMenu>
                                 <a *ngFor="let option of selector.options"
@@ -28,7 +29,8 @@
             </div>
             <div class="column" *ngIf="(selector.activeOption$ | async).fields as fields">
                 <div class="field">
-                    <label class="label" *ngIf="selector.state$ | async as state">
+                    <label class="label" *ngIf="selector.state$ | async as state"
+                        id="label-visualized-field">
                         <span *ngIf="state.name === 'resultscount' || state.name === 'termfrequency'">
                             Compare frequency by:
                         </span>
@@ -41,6 +43,7 @@
                     </label>
                     <div class="control">
                         <ia-dropdown *ngIf="fields.length > 1"
+                            labelledBy="label-visualized-field"
                             [value]="(selector.state$ | async).field">
                             <span iaDropdownLabel>{{(selector.state$ | async).field?.displayName}}</span>
                             <div iaDropdownMenu>


### PR DESCRIPTION
Some minor tweaks to make the dropdown component more accessible:

- The semantic roles of the button and popup were [button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role) and [menu](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role) respectively, but this is more for action menus. If you use a dropdown as a form element, the [combobox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) and [listbox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role) roles are more appropriate.
- Since dropdowns are now form elements, they also need to be explicitly labelled, so I added an extra input `labelledBy` to link the dropdown to the labelling element.
- A dropdown should include some properties like [`aria-controls`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) that refer to the ID of another element ("this controls that"). These IDs were assigned as constants, but this is a problem if you have multiple dropdowns on the same page. This is changed so the IDs are always unique. I think the solution for this is one I hadn't used in I-analyzer before; I got this strategy from [ng-bootstrap](https://github.com/ng-bootstrap/ng-bootstrap/).
- Addressed a slight deviation from the HTML specification in the keyboard controls: if you focus on the dropdown button when it is closed, and press the <kbd>Down arrow</kbd>, the popup should open and focus on the first element. This did not happen; now it does.

Also adds some extra logic to handle focus in the tagging control. E.g. when you select "create new" and the text input appears, you can immediately start typing instead of tabbing to the input first.