### PR TITLE
json schema endpoint + validation

### DIFF
--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from users.models import CustomUser
 from addcorpus.models import Corpus, CorpusDocumentationPage
 from addcorpus.python_corpora.save_corpus import load_and_save_all_corpora
+from addcorpus.json_corpora.validate import corpus_schema
 
 def test_no_corpora(db, settings, admin_client):
     Corpus.objects.all().delete()
@@ -160,3 +161,7 @@ def test_corpus_edit_views(admin_client: Client, json_corpus_definition: Dict, j
     assert status.is_success(response.status_code)
     assert len(response.data) == 1
 
+
+def test_corpus_schema_view(client):
+    response = client.get('/api/corpus/definition-schema')
+    assert response.data == corpus_schema()

--- a/backend/addcorpus/urls.py
+++ b/backend/addcorpus/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
-from addcorpus.views import CorpusImageView, CorpusView, CorpusDocumentationPageViewset, CorpusDocumentView
+from addcorpus.views import (
+    CorpusImageView, CorpusView, CorpusDocumentView, CorpusDefinitionSchemaView
+)
 
 urlpatterns = [
     path('', CorpusView.as_view({'get': 'list'})),
     path('image/<str:corpus>', CorpusImageView.as_view()),
     path('document/<str:corpus>/<str:filename>', CorpusDocumentView.as_view()),
+    path('definition-schema', CorpusDefinitionSchemaView.as_view()),
 ]

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -19,6 +19,7 @@ from rest_framework.permissions import (IsAuthenticated)
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
+from addcorpus.json_corpora.validate import corpus_schema
 
 
 class CorpusView(viewsets.ReadOnlyModelViewSet):
@@ -124,3 +125,13 @@ class CorpusDataFileViewSet(viewsets.ModelViewSet):
         info = get_csv_info(obj.file.path, sep=delimiter if delimiter else ',')
 
         return Response(info, HTTP_200_OK)
+
+
+class CorpusDefinitionSchemaView(APIView):
+    '''
+    View the JSON schema for corpus definitions
+    '''
+
+    def get(self, request, *args, **kwargs):
+        schema = corpus_schema()
+        return Response(schema, HTTP_200_OK)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "file-saver": "^2.0.5",
     "html-to-image": "^1.9.0",
     "iv-viewer": "^2.0.1",
+    "jsonschema": "^1.5.0",
     "lodash": "^4.17.21",
     "marked": "^4.1.1",
     "moment": "^2.29.4",

--- a/frontend/src/app/corpus-definitions/definition-json-upload/definition-json-upload.component.html
+++ b/frontend/src/app/corpus-definitions/definition-json-upload/definition-json-upload.component.html
@@ -17,9 +17,30 @@
 
 <div class="message is-danger" *ngIf="error$ | async as error">
     <div class="message-header">
-        Invalid file
+        Cannot read file
     </div>
-    <div class="message-body">
-        An error occurred when reading the file: {{error.message}}
+    <div class="message-body content">
+        <p>
+            An error occurred when reading the file: {{error.message}}. Is this a JSON file?
+        </p>
     </div>
 </div>
+
+<ng-container *ngIf="validationErrors$ | async as validationErrors">
+    <div class="message is-danger" *ngIf="validationErrors.length">
+        <div class="message-header">
+            Invalid data
+        </div>
+        <div class="message-body content">
+            <p>
+                The data in the file is not a valid corpus definition. The following
+                issues were found:
+            </p>
+            <ul>
+                <li *ngFor="let error of validationErrors">
+                    {{error.stack}}
+                </li>
+            </ul>
+        </div>
+    </div>
+</ng-container>

--- a/frontend/src/app/corpus-definitions/definition-json-upload/definition-json-upload.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/definition-json-upload/definition-json-upload.component.spec.ts
@@ -1,25 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DefinitionJsonUploadComponent } from './definition-json-upload.component';
+import { ApiService } from '@services';
+import { ApiServiceMock } from 'mock-data/api';
+import { SharedModule } from '@shared/shared.module';
 
 describe('DefinitionJsonUploadComponent', () => {
-  let component: DefinitionJsonUploadComponent;
-  let fixture: ComponentFixture<DefinitionJsonUploadComponent>;
+    let component: DefinitionJsonUploadComponent;
+    let fixture: ComponentFixture<DefinitionJsonUploadComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ DefinitionJsonUploadComponent ]
-    })
-    .compileComponents();
-  });
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [DefinitionJsonUploadComponent],
+            imports: [SharedModule],
+            providers: [
+                { provide: ApiService, useClass: ApiServiceMock },
+            ],
+        })
+            .compileComponents();
+    });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DefinitionJsonUploadComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(DefinitionJsonUploadComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.spec.ts
@@ -1,20 +1,45 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CorpusFormComponent } from './corpus-form.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { SlugifyPipe } from '@shared/pipes/slugify.pipe';
+import { StepsModule } from 'primeng/steps';
+import { MetaFormComponent } from '../meta-form/meta-form.component';
+import { FieldFormComponent } from '../field-form/field-form.component';
+import { UploadSampleComponent } from '../upload-sample/upload-sample.component';
+import { ApiService } from '@services';
+import { ApiServiceMock } from 'mock-data/api';
+import { SharedModule } from '@shared/shared.module';
+import { ActivatedRoute } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MultiSelectModule } from 'primeng/multiselect';
 
 describe('CorpusFormComponent', () => {
     let component: CorpusFormComponent;
     let fixture: ComponentFixture<CorpusFormComponent>;
 
+    const mockRoute = { snapshot: { params: {corpusID: 1} } };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [CorpusFormComponent],
-            imports: [HttpClientTestingModule, RouterTestingModule],
-            providers: [SlugifyPipe],
+            declarations: [
+                CorpusFormComponent,
+                MetaFormComponent,
+                FieldFormComponent,
+                UploadSampleComponent,
+            ],
+            imports: [
+                SharedModule,
+                StepsModule,
+                ReactiveFormsModule,
+                MultiSelectModule,
+            ],
+            providers: [
+                SlugifyPipe,
+                { provide: ActivatedRoute, useValue: mockRoute },
+                { provide: ApiService, useClass: ApiServiceMock },
+            ],
         }).compileComponents();
+
 
         fixture = TestBed.createComponent(CorpusFormComponent);
         component = fixture.componentInstance;

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FieldFormComponent } from './field-form.component';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
+import { SharedModule } from '@shared/shared.module';
+import { ReactiveFormsModule } from '@angular/forms';
 
 describe('FieldFormComponent', () => {
     let component: FieldFormComponent;
@@ -10,6 +12,7 @@ describe('FieldFormComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [FieldFormComponent],
+            imports: [SharedModule, ReactiveFormsModule],
             providers: [CorpusDefinitionService],
         }).compileComponents();
 

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.spec.ts
@@ -3,6 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MetaFormComponent } from './meta-form.component';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
 import { SlugifyPipe } from '@shared/pipes/slugify.pipe';
+import { SharedModule } from '@shared/shared.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MultiSelectModule } from 'primeng/multiselect';
+
 
 describe('MetaFormComponent', () => {
     let component: MetaFormComponent;
@@ -11,6 +15,11 @@ describe('MetaFormComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [MetaFormComponent],
+            imports: [
+                SharedModule,
+                ReactiveFormsModule,
+                MultiSelectModule,
+            ],
             providers: [CorpusDefinitionService, SlugifyPipe],
         }).compileComponents();
 

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -295,6 +295,10 @@ export class ApiService {
         return this.http.delete(`/api/corpus/definitions/${corpusID}/`);
     }
 
+    public corpusSchema(): Observable<any> {
+        return this.http.get('/api/corpus/definition-schema');
+    }
+
     // Corpus datafiles
     public createDataFile(
         corpusId: number,

--- a/frontend/src/mock-data/api.ts
+++ b/frontend/src/mock-data/api.ts
@@ -121,4 +121,8 @@ export class ApiServiceMock {
     listDataFiles(): Observable<CorpusDataFile[]> {
         return of([]);
     }
+
+    corpusSchema(): Observable<any> {
+        return of({});
+    }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5951,6 +5951,11 @@ jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
+jsonschema@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
+  integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
+
 karma-chrome-launcher@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz#eb9c95024f2d6dfbb3748d3415ac9b381906b9a9"


### PR DESCRIPTION
- Adds an API endpoint for the corpus JSON schema (close #1737)
- Validates corpus JSON uploads against the schema. The feedback for invalid JSONs is taken straight from the validation package.


Screenshot:

![screenshot of I-analyzer. Shows file upload and an error message detailing issues with an invalid JSON file](https://github.com/user-attachments/assets/529268a0-a6ce-4487-888a-92366785a368)
