### PR TITLE
async index jobs

### DIFF
--- a/backend/ianalyzer/celery.py
+++ b/backend/ianalyzer/celery.py
@@ -16,7 +16,7 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()
-
+app.autodiscover_tasks(packages=['indexing'], related_name='run_job')
 
 @app.task(bind=True)
 def debug_task(self):

--- a/backend/indexing/run_job.py
+++ b/backend/indexing/run_job.py
@@ -105,7 +105,16 @@ def perform_indexing(job: IndexJob):
     '''
 
     chain = job_chain(job)
-    return chain.apply(job)
+    return chain.apply()
+
+
+def perform_indexing_async(job: IndexJob):
+    '''
+    Run an IndexJob asynchronously (through celery)
+    '''
+
+    chain = job_chain(job)
+    return chain.apply_async()
 
 
 def _validate_job_start(job: IndexJob):

--- a/documentation/Indexing-corpora.md
+++ b/documentation/Indexing-corpora.md
@@ -35,8 +35,10 @@ Some options that may be useful for development:
 
 See [Indexing on server](documentation/Indexing-on-server.md) for more information about production-specific settings.
 
-## IndexJob log
+## Managing index jobs through the admin site
 
-When you start the command, the application will save an `IndexJob` that represents the action. These can also be viewed in the admin site.
+When you run `index my-corpus`, the index process will start immediately. This process will store an `IndexJob` in the database that represents the action, which you may use as a log. You can view index jobs on the admin site.
 
-IndexJobs are not automatically deleted when the command completes, but can be freely deleted at that point.
+If you want to create a job to run later, you can use `--create-only` in the index command. After this, you can select the job in the admin site and use the action "start selected jobs". This will run the job asynchronously using celery.
+
+You can also use the admin site to create or edit index jobs (and then run them). However, the command line is typically faster and easier.


### PR DESCRIPTION
Part of https://github.com/CentreForDigitalHumanities/I-analyzer/issues/1697

Adds an action to start index jobs from the admin site. With this addition, you could create, index, and publish a corpus entirely through the admin, no terminal required.

I'm not sure if kicking off indexing from the admin site is the future, but the action is just a few lines of code. The main addition is that index jobs can now be scheduled through celery, which is something we need for https://github.com/CentreForDigitalHumanities/I-analyzer/issues/1007

Not implemented:
- interrupting jobs
- if we want the admin site as a viable tool for indexing, you need some way to see error logs.