### PR TITLE
delpher documentation

### DIFF
--- a/backend/corpora/dutchnewspapers/description/description_public.md
+++ b/backend/corpora/dutchnewspapers/description/description_public.md
@@ -4,7 +4,13 @@ This corpus contains the public portion of the [Delpher newspapers dataset](http
 
 Are you interested to know which countries featured in the news in the 18th century, and which did not? Or how newspapers reported on reforms in the Batavian Republic? Delpher newspapers is a great resource for research into historical newspapers. But this dataset is also useful for broader-based history projects. It gives a peek behind the scenes of what was going on in society.
 
-The full collection comprises almost 2 million newspapers dating from 1618 until 1995. This collection contains publications published at least 140 years ago, which are no longer subject to copyright.
+The full *Delpher newspapers* collection comprises almost 2 million newspapers dating from 1618 until 1995. This collection contains publications published at least 140 years ago, which are no longer subject to copyright.
 
 It includes major national newspapers, such as the *Algemeen Handelsblad*, as well as regional newspapers, such as the *Leydse courant*, and colonial papers, such as the *Java-bode*.
 
+Please note that our collection currently includes only the newspaper set from Delpher and does not (yet) contain the [historical magazine collection](https://www.kb.nl/en/research-find/datasets/delpher-magazines) from the period 1800-2000.
+
+### Recent newspapers (1876-1995)
+
+All users have direct access to the Delpher newspaper dataset for the period 1600–1876. A more recent dataset, which includes newspapers up to 1995, is also available for exploration in I-Analyzer. However, access requires prior permission from the rightsholder, The National Library of the Netherlands (KB). To use the full newspaper dataset, you must first complete and sign an individual agreement to comply with the KB's usage conditions. This form can be requested via
+[cdh@uu.nl](mailto:cdh@uu.nl), after which we can assist you with finalizing the application process.

--- a/backend/corpora/dutchnewspapers/description/description_public.md
+++ b/backend/corpora/dutchnewspapers/description/description_public.md
@@ -1,0 +1,10 @@
+This corpus contains the public portion of the [Delpher newspapers dataset](https://www.kb.nl/en/research-find/datasets/delpher-newspapers). This is a collection of Dutch newspapers published between 1618 and 1876, maintained by the KB, the National Library of the Netherlands.
+
+### What is in Delpher Newspapers?
+
+Are you interested to know which countries featured in the news in the 18th century, and which did not? Or how newspapers reported on reforms in the Batavian Republic? Delpher newspapers is a great resource for research into historical newspapers. But this dataset is also useful for broader-based history projects. It gives a peek behind the scenes of what was going on in society.
+
+The full collection comprises almost 2 million newspapers dating from 1618 until 1995. This collection contains publications published at least 140 years ago, which are no longer subject to copyright.
+
+It includes major national newspapers, such as the *Algemeen Handelsblad*, as well as regional newspapers, such as the *Leydse courant*, and colonial papers, such as the *Java-bode*.
+

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -38,6 +38,7 @@ class DutchNewspapersPublic(XMLCorpusDefinition):
     image = 'dutchnewspapers.jpg'
     languages = ['nl']
     category = 'periodical'
+    description_page = 'description_public.md'
     citation_page = 'citation_public.md'
 
     @property


### PR DESCRIPTION
Part of https://github.com/CentreForDigitalHumanities/I-analyzer/issues/991

Adds an info page for the public Delpher corpus. Also includes a (Jill-approved) explanation about accessing the full dataset.