### PR TITLE
manage/schedule index jobs from CLI

### DIFF
--- a/backend/indexing/celery_utils.py
+++ b/backend/indexing/celery_utils.py
@@ -1,0 +1,21 @@
+import warnings
+
+from django.conf import settings
+from ianalyzer.celery import app
+
+
+def worker_is_active() -> bool:
+    '''
+    Check whether the app can connect to an active worker.
+    '''
+    inspector = app.control.inspect()
+    try:
+        workers = inspector.active()
+        return workers is not None and len(workers) > 0
+    except:
+        return False
+
+
+def warn_if_no_worker() -> None:
+    if not worker_is_active():
+        warnings.warn('No active celery worker.')

--- a/backend/indexing/command_utils.py
+++ b/backend/indexing/command_utils.py
@@ -1,0 +1,18 @@
+'''
+Shared functions for django-admin commands
+'''
+
+from indexing.models import IndexJob
+from indexing.run_job import perform_indexing, perform_indexing_async, mark_tasks_stopped
+
+
+def run_job(job: IndexJob, run_async: bool):
+    if run_async:
+        perform_indexing_async(job)
+        print('Job scheduled.')
+    else:
+        try:
+            perform_indexing(job)
+        except KeyboardInterrupt as e:
+            print('Aborting tasks...')
+            mark_tasks_stopped(job)

--- a/backend/indexing/command_utils.py
+++ b/backend/indexing/command_utils.py
@@ -2,8 +2,25 @@
 Shared functions for django-admin commands
 '''
 
+from argparse import ArgumentParser
+
 from indexing.models import IndexJob
 from indexing.run_job import perform_indexing, perform_indexing_async, mark_tasks_stopped
+
+def add_create_only_argument(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        '--create-only',
+        action='store_true',
+        help='''Save an IndexJob for this command, but don't run it.'''
+    )
+
+def add_async_argument(parser: ArgumentParser, extra_help: str = '') -> None:
+    parser.add_argument(
+        '--async',
+        action='store_true',
+        dest='run_async', # "async" is a Python keyword
+        help=f'Run job asynchronously using Celery. {extra_help}',
+    )
 
 
 def run_job(job: IndexJob, run_async: bool):

--- a/backend/indexing/management/commands/alias.py
+++ b/backend/indexing/management/commands/alias.py
@@ -2,7 +2,7 @@ from django.core.management import BaseCommand
 
 from addcorpus.models import Corpus
 from indexing.create_job import create_alias_job
-from indexing.command_utils import run_job
+from indexing.command_utils import run_job, add_create_only_argument, add_async_argument
 
 class Command(BaseCommand):
     help = '''
@@ -28,18 +28,8 @@ class Command(BaseCommand):
                 deleted.'''
         )
 
-        parser.add_argument(
-            '--create-only',
-            action='store_true',
-            help='''Save an IndexJob for this command, but don't run it.''',
-        )
-        parser.add_argument(
-            '--async',
-            action='store_true',
-            dest='run_async', # "async" is a Python keyword
-            help='''Run the IndexJob asynchronously using Celery. Cannot be used in
-                combination with --create-only.'''
-        )
+        add_create_only_argument(parser)
+        add_async_argument(parser, 'Cannot be used in combination with --create-only.')
 
 
     def handle(self, corpus, clean=False, create_only=False, run_async=False, **options):

--- a/backend/indexing/management/commands/index.py
+++ b/backend/indexing/management/commands/index.py
@@ -6,7 +6,7 @@ from addcorpus.python_corpora.load_corpus import load_corpus_definition
 from addcorpus.python_corpora.save_corpus import load_all_corpus_definitions
 from addcorpus.models import Corpus
 from indexing.create_job import create_indexing_job
-from indexing.command_utils import run_job
+from indexing.command_utils import run_job, add_create_only_argument, add_async_argument
 
 
 class Command(BaseCommand):
@@ -88,18 +88,8 @@ class Command(BaseCommand):
                 command after indexing is complete.'''
         )
 
-        parser.add_argument(
-            '--create-only',
-            action='store_true',
-            help='''Save an IndexJob for this command, but don't run it.'''
-        )
-        parser.add_argument(
-            '--async',
-            action='store_true',
-            dest='run_async', # "async" is a Python keyword
-            help='''Run the IndexJob asynchronously using Celery. Cannot be used in
-                combination with --create-only.'''
-        )
+        add_create_only_argument(parser)
+        add_async_argument(parser, 'Cannot be used in combination with --create-only.')
 
     def handle(
             self, corpus,

--- a/backend/indexing/management/commands/index.py
+++ b/backend/indexing/management/commands/index.py
@@ -126,6 +126,8 @@ class Command(BaseCommand):
             rollover, update
         )
 
+        print(f'Created IndexJob #{job.pk}')
+
         if not create_only:
             try:
                 perform_indexing(job)

--- a/backend/indexing/management/commands/indexjob.py
+++ b/backend/indexing/management/commands/indexjob.py
@@ -5,8 +5,7 @@ from sys import stdout
 from django.core.management import BaseCommand
 
 from indexing.models import IndexJob, TaskStatus
-from indexing.run_job import perform_indexing
-from indexing.command_utils import run_job
+from indexing.command_utils import run_job, add_async_argument
 
 class Command(BaseCommand):
     help = '''
@@ -35,11 +34,10 @@ class Command(BaseCommand):
             nargs='*',
             help='IDs of the jobs to which the action should be applied',
         )
-        parser.add_argument(
-            '--async',
-            action='store_true',
-            dest='run_async',
-            help='Run job asynchronously using Celery. Only applies with "start".',
+
+        add_async_argument(
+            parser,
+            'Only applicable with "start"',
         )
 
     def handle(self, action: str, ids: List[int], **options):

--- a/backend/indexing/management/commands/indexjob.py
+++ b/backend/indexing/management/commands/indexjob.py
@@ -6,6 +6,7 @@ from django.core.management import BaseCommand
 
 from indexing.models import IndexJob, TaskStatus
 from indexing.run_job import perform_indexing
+from indexing.command_utils import run_job
 
 class Command(BaseCommand):
     help = '''
@@ -33,6 +34,12 @@ class Command(BaseCommand):
             type=int,
             nargs='*',
             help='IDs of the jobs to which the action should be applied',
+        )
+        parser.add_argument(
+            '--async',
+            action='store_true',
+            dest='run_async',
+            help='Run job asynchronously using Celery. Only applies with "start".',
         )
 
     def handle(self, action: str, ids: List[int], **options):
@@ -94,4 +101,4 @@ class Command(BaseCommand):
                 return
 
             print(f'Starting job: {job.id}')
-            perform_indexing(job)
+            run_job(job, options.get('run_async'))

--- a/backend/indexing/management/commands/indexjob.py
+++ b/backend/indexing/management/commands/indexjob.py
@@ -1,0 +1,86 @@
+from typing import List
+from csv import DictWriter
+from sys import stdout
+
+from django.core.management import BaseCommand
+
+from indexing.models import IndexJob, TaskStatus
+from indexing.run_job import perform_indexing
+
+class Command(BaseCommand):
+    help = '''
+    Create, populate or clear elasticsearch indices for corpora.
+    '''
+
+    actions = ['list', 'show', 'start']
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'action',
+            choices=self.actions,
+            help='Action keyword. Options: '
+                'list (show brief overview), show (show more information about a job, '
+                'including its list of tasks); start (start a job)',
+        )
+        parser.add_argument(
+            'ids',
+            type=int,
+            nargs='*',
+            help='IDs of the jobs to which the action should be applied',
+        )
+
+    def handle(self, action: str, ids: List[int], **options):
+        if action == 'list':
+            self.list(ids)
+        if action == 'show':
+            for id in ids:
+                self.show(id)
+        if action == 'start':
+            for id in ids:
+                self.start(id)
+
+    def list(self, ids: List[int]):
+        if len(ids):
+            jobs = IndexJob.objects.filter(id__in=ids)
+        else:
+            jobs = IndexJob.objects.all()
+
+        writer = DictWriter(
+            fieldnames=['id', 'corpus', 'created', 'status'],
+            f=stdout,
+            delimiter='\t',
+        )
+        writer.writeheader()
+        for job in jobs:
+            writer.writerow({
+                'id': job.id,
+                'corpus': job.corpus,
+                'created': job.created,
+                'status': job.status()
+            })
+
+    def show(self, id: int):
+        job = IndexJob.objects.get(id=id)
+        print()
+        print('JOB:', job.id)
+        print('CORPUS:', job.corpus)
+        print('CREATED ON:', job.created)
+        print('STATUS:', job.status())
+
+        print('TASKS:')
+        for task in job.tasks():
+            print('- ', task, f'[{task.status}]')
+
+        print()
+
+    def start(self, id: int):
+        job = IndexJob.objects.get(id=id)
+
+        if job.status() != TaskStatus.CREATED:
+            print(
+                f'Job {job.id} cannot be started: current status is {job.status()}'
+            )
+            return
+
+        print(f'Starting job: {job.id}')
+        perform_indexing(job)

--- a/backend/indexing/models.py
+++ b/backend/indexing/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from elasticsearch import Elasticsearch
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 from itertools import chain
 from django.contrib import admin
 

--- a/backend/indexing/models.py
+++ b/backend/indexing/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from elasticsearch import Elasticsearch
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 from itertools import chain
 from django.contrib import admin
 

--- a/backend/indexing/run_job.py
+++ b/backend/indexing/run_job.py
@@ -17,6 +17,7 @@ from indexing.run_management_tasks import (
     update_index_settings, remove_alias, add_alias, delete_index
 )
 from indexing.run_update_task import run_update_task
+from indexing.celery_utils import warn_if_no_worker
 
 
 logger = logging.getLogger('indexing')
@@ -101,6 +102,7 @@ def perform_indexing_async(job: IndexJob):
     Run an IndexJob asynchronously (through celery)
     '''
 
+    warn_if_no_worker()
     chain = job_chain(job)
     return chain.apply_async()
 

--- a/documentation/Celery.md
+++ b/documentation/Celery.md
@@ -8,6 +8,7 @@ Celery is used for
 - Search results downloads with more than 10.000 documents
 - The term frequency visualisation
 - The ngram visualisation
+- Indexing documents (can also be done synchronously, see [indexing corpora](./Indexing-corpora.md))
 
 ## Running celery
 
@@ -60,7 +61,6 @@ Then open `localhost:5555` in your browser to see the flower interface.
 
 ## Developing with celery
 
-- The arguments and outputs for celery tasks must be JSON-serialisable. For example, a task function can have a user ID string as an argument, but not a `CustomUser` object.
 - Use `group` to run tasks in parallel and `chain` to run tasks in series. You can use groups in chains, chains in groups, chains in chains, etc.
 - You can use flower (see above) for an overview of your celery tasks. Note that groups and chains are not tasks themselves, and will not show up as tasks on Flower.
 - For easier debugging and testing, keep your tasks simple and outfactor complicated functionality to 'normal' functions.

--- a/documentation/Indexing-corpora.md
+++ b/documentation/Indexing-corpora.md
@@ -35,10 +35,10 @@ Some options that may be useful for development:
 
 See [Indexing on server](documentation/Indexing-on-server.md) for more information about production-specific settings.
 
-## Managing index jobs through the admin site
+## Scheduling and managing index jobs
 
-When you run `index my-corpus`, the index process will start immediately. This process will store an `IndexJob` in the database that represents the action, which you may use as a log. You can view index jobs on the admin site.
+When you run `index my-corpus`, the index process will start immediately. This process will store an `IndexJob` in the database that represents the action, which you may use as a log. You can use `yarn django indexjob list` to view an overview of all indexjobs, and `yarn django indexjob show {id}` to view details about a specific job. You can also view index jobs on the admin site.
 
-If you want to create a job to run later, you can use `--create-only` in the index command. After this, you can select the job in the admin site and use the action "start selected jobs". This will run the job asynchronously using celery.
+If you want to create a job to run later, you can use `--create-only` in the index command. After this, you can start the job from the command line using `yarn django indexjob start {id}`. Alternatively, you can select the job in the admin site and use the action "start selected jobs". This will run the job asynchronously using celery.
 
 You can also use the admin site to create or edit index jobs (and then run them). However, the command line is typically faster and easier.

--- a/documentation/Indexing-corpora.md
+++ b/documentation/Indexing-corpora.md
@@ -37,8 +37,22 @@ See [Indexing on server](documentation/Indexing-on-server.md) for more informati
 
 ## Scheduling and managing index jobs
 
-When you run `index my-corpus`, the index process will start immediately. This process will store an `IndexJob` in the database that represents the action, which you may use as a log. You can use `yarn django indexjob list` to view an overview of all indexjobs, and `yarn django indexjob show {id}` to view details about a specific job. You can also view index jobs on the admin site.
+When you run `index my-corpus`, the index process will start immediately. This process will store an `IndexJob` in the database that represents the action, which you may use as a log. You can use the `indexjob` command to view index jobs:
 
-If you want to create a job to run later, you can use `--create-only` in the index command. After this, you can start the job from the command line using `yarn django indexjob start {id}`. Alternatively, you can select the job in the admin site and use the action "start selected jobs". This will run the job asynchronously using celery.
+```sh
+python manage.py indexjob list # view a list of all index jobs
+python manage.py indexjob show 42 # view details for an index job
+python manage.py indexjob show 42 --verbosity 2 # include all task parameters
+```
+
+You can also view index jobs on the admin site.
+
+If you want to create a job to run later, you can use `--create-only` in the index command. After this, you can start the job from the command line:
+
+```sh
+python manage.py indexjob start 42
+```
+
+Alternatively, you can select the job in the admin site and use the action "start selected jobs". This will run the job asynchronously using celery.
 
 You can also use the admin site to create or edit index jobs (and then run them). However, the command line is typically faster and easier.

--- a/documentation/Indexing-corpora.md
+++ b/documentation/Indexing-corpora.md
@@ -37,22 +37,35 @@ See [Indexing on server](documentation/Indexing-on-server.md) for more informati
 
 ## Scheduling and managing index jobs
 
-When you run `index my-corpus`, the index process will start immediately. This process will store an `IndexJob` in the database that represents the action, which you may use as a log. You can use the `indexjob` command to view index jobs:
+When you run `index my-corpus`, the default options will start the process immediately, and store an `IndexJob` as a record. You can use the command line or the django admin to manage index jobs. It is also possible to run jobs asynchronously.
+
+### Using the command line
+
+The `index` command will store an `IndexJob` in the database that represents the action, which you may use as a log. You can use the `indexjob` command to view index jobs:
 
 ```sh
 python manage.py indexjob list # view a list of all index jobs
-python manage.py indexjob show 42 # view details for an index job
-python manage.py indexjob show 42 --verbosity 2 # include all task parameters
+python manage.py indexjob show 42 # inspect an index job
+python manage.py indexjob show 42 --verbose # include all task parameters
 ```
 
-You can also view index jobs on the admin site.
-
-If you want to create a job to run later, you can use `--create-only` in the index command. After this, you can start the job from the command line:
+If you want to create a job to run later, you can use `--create-only` in the `index` command. After this, you can start the job from the command line using `indexjob start`:
 
 ```sh
+python manage.py index my-corpus --create-only
+# > Created IndexJob #42
 python manage.py indexjob start 42
 ```
 
-Alternatively, you can select the job in the admin site and use the action "start selected jobs". This will run the job asynchronously using celery.
+When you start an index job through the `index`, `alias`, or `indexjob` commands, you can use the `--async` flag to schedule the job via [Celery](./Celery.md) instead of running it in your terminal:
 
-You can also use the admin site to create or edit index jobs (and then run them). However, the command line is typically faster and easier.
+```sh
+python manage.py index my-corpus --async
+```
+
+### Using the admin site
+
+You can also manage index jobs using the admin site. Here you can view, create and edit jobs. To run a job from the admin site, select the job in the overview and use the action "start selected jobs". Jobs started from the admin are always run via Celery.
+
+Note that in most cases, it is easier to create jobs via the command line, which offers a more streamlined experience.
+


### PR DESCRIPTION
This adds some functionality to the backend CLI that is currently only available on the admin site:

- View index jobs with `indexjob list` and `indexjob show `
- Start created jobs with `indexjob start`
- When running index jobs from the command line, use `--async` to run them through celery.