### PR TITLE
word models graph

### DIFF
--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -11,7 +11,9 @@ def local_graph_data(corpus_name: str, query_term: str):
         {
             'start_year': wm['start_year'],
             'end_year': wm['end_year'],
-            'data': local_graph_in_timeframe(wm, query_term)
+            'graph': _graph_vega_doc(
+                *local_graph_in_timeframe(wm, query_term)
+            )
         }
         for wm in wm_list
     ]
@@ -21,10 +23,7 @@ def local_graph_in_timeframe(wm, query_term: str):
     nodes = _graph_nodes(wm, query_term)
     links = _graph_links(wm, nodes)
 
-    return {
-        'nodes': nodes,
-        'links': links
-    }
+    return nodes, links
 
 
 def _graph_nodes(wm, query_term):
@@ -68,3 +67,151 @@ def _graph_links(wm, nodes):
                     })
 
     return links
+
+
+def _graph_vega_doc(nodes, links):
+    return {
+        "$schema": "https://vega.github.io/schema/vega/v5.json",
+        "description": "A node-link diagram of neighbouring words",
+        "width": 700,
+        "height": 500,
+        "padding": 0,
+        "autosize": "none",
+
+        "signals": [
+            { "name": "cx", "update": "width / 2" },
+            { "name": "cy", "update": "height / 2" },
+            { "name": "nodeCharge", "value": -30,
+            "bind": {"input": "range", "min":-100, "max": 10, "step": 1} },
+            { "name": "linkDistance", "value": 30,
+            "bind": {"input": "range", "min": 5, "max": 100, "step": 1} },
+            { "name": "static", "value": True,
+            "bind": {"input": "checkbox"} },
+            {
+            "description": "State variable for active node fix status.",
+            "name": "fix", "value": False,
+            "on": [
+                {
+                "events": "symbol:pointerout[!event.buttons], window:pointerup",
+                "update": "false"
+                },
+                {
+                "events": "symbol:pointerover",
+                "update": "fix || true"
+                },
+                {
+                "events": "[symbol:pointerdown, window:pointerup] > window:pointermove!",
+                "update": "xy()",
+                "force": True
+                }
+            ]
+            },
+            {
+            "description": "Graph node most recently interacted with.",
+            "name": "node", "value": None,
+            "on": [
+                {
+                "events": "symbol:pointerover",
+                "update": "fix === true ? item() : node"
+                }
+            ]
+            },
+            {
+            "description": "Flag to restart Force simulation upon data changes.",
+            "name": "restart", "value": False,
+            "on": [
+                {"events": {"signal": "fix"}, "update": "fix && fix.length"}
+            ]
+            }
+        ],
+
+        "data": [
+            {
+            "name": "node-data",
+            'values': nodes,
+            "format": {"type": "json", "property": "nodes"}
+            },
+            {
+            "name": "link-data",
+            'values': links,
+            "format": {"type": "json", "property": "links"}
+            }
+        ],
+
+        "scales": [
+            {
+            "name": "color",
+            "type": "linear",
+            "domain": {"data": "node-data", "field": "similarity"},
+            "range": {"scheme": "blues"}
+            }
+        ],
+
+        "marks": [
+            {
+            "name": "nodes",
+            "type": "symbol",
+            "zindex": 1,
+
+            "from": {"data": "node-data"},
+            "on": [
+                {
+                "trigger": "fix",
+                "modify": "node",
+                "values": "fix === true ? {fx: node.x, fy: node.y} : {fx: fix[0], fy: fix[1]}"
+                },
+                {
+                "trigger": "!fix",
+                "modify": "node", "values": "{fx: null, fy: null}"
+                }
+            ],
+
+            "encode": {
+                "enter": {
+                "fill": {"scale": "color", "field": "group"},
+                "stroke": {"value": "white"}
+                },
+                "update": {
+                "size": 32,
+                "cursor": {"value": "pointer"}
+                }
+            },
+
+            "transform": [
+                {
+                "type": "force",
+                "iterations": 300,
+                "restart": {"signal": "restart"},
+                "static": {"signal": "static"},
+                "signal": "force",
+                "forces": [
+                    {"force": "center", "x": {"signal": "cx"}, "y": {"signal": "cy"}},
+                    {"force": "collide", "radius": 8},
+                    {"force": "nbody", "strength": {"signal": "nodeCharge"}},
+                    {"force": "link", "links": "link-data", "distance": {"signal": "linkDistance"}}
+                ]
+                }
+            ]
+            },
+            {
+            "type": "path",
+            "from": {"data": "link-data"},
+            "interactive": False,
+            "encode": {
+                "update": {
+                "stroke": {"value": "#ccc"},
+                "strokeWidth": {"value": 0.5}
+                }
+            },
+            "transform": [
+                {
+                "type": "linkpath",
+                "require": {"signal": "force"},
+                "shape": "line",
+                "sourceX": "datum.source.x", "sourceY": "datum.source.y",
+                "targetX": "datum.target.x", "targetY": "datum.target.y"
+                }
+            ]
+            }
+        ]
+    }

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -2,7 +2,7 @@ from itertools import chain
 from typing import List
 
 from addcorpus.python_corpora.load_corpus import load_corpus_definition
-from wordmodels.utils import load_word_models
+from wordmodels.utils import load_word_models, word_in_model
 from wordmodels.similarity import find_n_most_similar, term_similarity
 
 def local_graph_data(corpus_name: str, query_term: str):
@@ -39,6 +39,9 @@ def _format_time(wm):
 
 
 def _graph_nodes(wm, query_term):
+    if not word_in_model(query_term, wm):
+        return []
+
     neighbours = find_n_most_similar(wm, query_term, 10)
     query_node = {
         'term': query_term,
@@ -61,6 +64,9 @@ def _graph_nodes(wm, query_term):
 
 
 def _graph_links(wm, nodes):
+    if not len(nodes):
+        return []
+
     threshold = min(
         node['similarity'] for node in nodes
     )

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -46,4 +46,25 @@ def _graph_nodes(wm, query_term):
 
 
 def _graph_links(wm, nodes):
-    return []
+    threshold = min(
+        node['similarity'] for node in nodes
+    )
+
+    links = []
+
+    for n1 in nodes:
+        for n2 in nodes:
+            i1 = n1['index']
+            i2 = n2['index']
+            if i1 != i2:
+                term1 = n1['term']
+                term2 = n2['term']
+                similarity = term_similarity(wm, term1, term2)
+                if similarity and similarity > threshold:
+                    links.append({
+                        'from': i1,
+                        'to': i2,
+                        'value': similarity
+                    })
+
+    return links

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -21,7 +21,8 @@ def local_graph_data(corpus_name: str, query_term: str):
     links = list(chain(*link_data))
 
     return {
-        'graph': _graph_vega_doc(times, nodes, links)
+        'graph': _graph_vega_doc(times, nodes, links),
+        'table': _graph_table_data(nodes, links)
     }
 
 
@@ -281,3 +282,16 @@ def _graph_vega_doc(timeframes, nodes, links):
             },
         ]
     }
+
+def _graph_table_data(nodes, links):
+    find_term = lambda i: next(node for node in nodes if node['index'] == i)['term']
+
+    return [
+        {
+            'timeframe': link['timeframe'],
+            'term1': find_term(link['source']),
+            'term2': find_term(link['target']),
+            'similarity': round(link['value'], 4),
+        }
+        for link in links
+    ]

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -83,8 +83,6 @@ def _graph_vega_doc(nodes, links):
         "signals": [
             { "name": "cx", "update": "width / 2" },
             { "name": "cy", "update": "height / 2" },
-            { "name": "nodeCharge", "value": -30,
-                "bind": {"input": "range", "min":-100, "max": 10, "step": 1} },
             { "name": "linkDistance", "value": 150,
                 "bind": {"input": "range", "min": 20, "max": 300, "step": 1} },
             { "name": "static", "value": True,
@@ -198,7 +196,7 @@ def _graph_vega_doc(nodes, links):
                         "forces": [
                             {"force": "center", "x": {"signal": "cx"}, "y": {"signal": "cy"}},
                             {"force": "collide", "radius": 30},
-                            {"force": "nbody", "strength": "nodeCharge"},
+                            {"force": "nbody", "strength": -30},
                             {"force": "link", "links": "link-data", "distance": {"signal": "linkDistance"}}
                         ]
                     }

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -123,7 +123,7 @@ def _graph_vega_doc(timeframes, nodes, links):
             { "name": "cy", "update": "height / 2" },
             {
                 'name': 'timeframe',
-                'value': timeframes[0],
+                'value': timeframes[-1],
                 'bind': {
                     'input': 'select',
                     'name': 'time frame',

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -63,6 +63,16 @@ def _graph_nodes(wm, query_term):
     )
     return [query_node, *neighbour_nodes]
 
+def pairs(items, reflexive=False):
+    '''
+    Returns all unique pairs in a list
+    '''
+
+    for i in range(len(items)):
+        start = i if reflexive else i + 1
+        for j in range(start, len(items)):
+            yield items[i], items[j]
+
 
 def _graph_links(wm, nodes):
     if not len(nodes):
@@ -74,21 +84,19 @@ def _graph_links(wm, nodes):
 
     links = []
 
-    for n1 in nodes:
-        for n2 in nodes:
-            i1 = n1['index']
-            i2 = n2['index']
-            if i1 != i2:
-                term1 = n1['term']
-                term2 = n2['term']
-                similarity = term_similarity(wm, term1, term2)
-                if similarity and similarity >= threshold:
-                    links.append({
-                        'source': i1,
-                        'target': i2,
-                        'value': similarity,
-                        'timeframe': _format_time(wm),
-                    })
+    for n1, n2 in pairs(nodes):
+        i1 = n1['index']
+        i2 = n2['index']
+        term1 = n1['term']
+        term2 = n2['term']
+        similarity = term_similarity(wm, term1, term2)
+        if similarity and similarity >= threshold:
+            links.append({
+                'source': i1,
+                'target': i2,
+                'value': similarity,
+                'timeframe': _format_time(wm),
+            })
 
     return links
 

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -27,7 +27,7 @@ def local_graph_in_timeframe(wm, query_term: str):
 
 
 def _graph_nodes(wm, query_term):
-    neighbours = find_n_most_similar(wm, query_term, 5)
+    neighbours = find_n_most_similar(wm, query_term, 10)
     query_node = {
         'term': query_term,
         'index': 0,
@@ -61,7 +61,7 @@ def _graph_links(wm, nodes):
                 term1 = n1['term']
                 term2 = n2['term']
                 similarity = term_similarity(wm, term1, term2)
-                if similarity and similarity > threshold:
+                if similarity and similarity >= threshold:
                     links.append({
                         'source': i1,
                         'target': i2,
@@ -87,8 +87,8 @@ def _graph_vega_doc(nodes, links):
                 "bind": {"input": "range", "min": 1, "max": 50, "step": 1} },
             { "name": "nodeCharge", "value": -30,
                 "bind": {"input": "range", "min":-100, "max": 10, "step": 1} },
-            { "name": "linkDistance", "value": 30,
-                "bind": {"input": "range", "min": 5, "max": 100, "step": 1} },
+            { "name": "linkDistance", "value": 75,
+                "bind": {"input": "range", "min": 20, "max": 200, "step": 1} },
             { "name": "static", "value": True,
                 "bind": {"input": "checkbox"} },
             {

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -84,48 +84,48 @@ def _graph_vega_doc(nodes, links):
             { "name": "cx", "update": "width / 2" },
             { "name": "cy", "update": "height / 2" },
             { "name": "nodeRadius", "value": 8,
-            "bind": {"input": "range", "min": 1, "max": 50, "step": 1} },
+                "bind": {"input": "range", "min": 1, "max": 50, "step": 1} },
             { "name": "nodeCharge", "value": -30,
-            "bind": {"input": "range", "min":-100, "max": 10, "step": 1} },
+                "bind": {"input": "range", "min":-100, "max": 10, "step": 1} },
             { "name": "linkDistance", "value": 30,
-            "bind": {"input": "range", "min": 5, "max": 100, "step": 1} },
+                "bind": {"input": "range", "min": 5, "max": 100, "step": 1} },
             { "name": "static", "value": True,
-            "bind": {"input": "checkbox"} },
+                "bind": {"input": "checkbox"} },
             {
-            "description": "State variable for active node fix status.",
-            "name": "fix", "value": False,
-            "on": [
-                {
-                "events": "symbol:pointerout[!event.buttons], window:pointerup",
-                "update": "false"
-                },
-                {
-                "events": "symbol:pointerover",
-                "update": "fix || true"
-                },
-                {
-                "events": "[symbol:pointerdown, window:pointerup] > window:pointermove!",
-                "update": "xy()",
-                "force": True
-                }
-            ]
+                "description": "State variable for active node fix status.",
+                "name": "fix", "value": False,
+                "on": [
+                    {
+                        "events": "symbol:pointerout[!event.buttons], window:pointerup",
+                        "update": "false"
+                    },
+                    {
+                        "events": "symbol:pointerover",
+                        "update": "fix || true"
+                    },
+                    {
+                        "events": "[symbol:pointerdown, window:pointerup] > window:pointermove!",
+                        "update": "xy()",
+                        "force": True
+                    }
+                ]
             },
             {
             "description": "Graph node most recently interacted with.",
             "name": "node", "value": None,
             "on": [
-                {
-                "events": "symbol:pointerover",
-                "update": "fix === true ? item() : node"
-                }
-            ]
+                    {
+                        "events": "symbol:pointerover",
+                        "update": "fix === true ? item() : node"
+                    }
+                ]
             },
             {
-            "description": "Flag to restart Force simulation upon data changes.",
-            "name": "restart", "value": False,
-            "on": [
-                {"events": {"signal": "fix"}, "update": "fix && fix.length"}
-            ]
+                "description": "Flag to restart Force simulation upon data changes.",
+                "name": "restart", "value": False,
+                "on": [
+                    {"events": {"signal": "fix"}, "update": "fix && fix.length"}
+                ]
             }
         ],
 
@@ -160,40 +160,40 @@ def _graph_vega_doc(nodes, links):
             "from": {"data": "node-data"},
             "on": [
                 {
-                "trigger": "fix",
-                "modify": "node",
-                "values": "fix === true ? {fx: node.x, fy: node.y} : {fx: fix[0], fy: fix[1]}"
+                    "trigger": "fix",
+                    "modify": "node",
+                    "values": "fix === true ? {fx: node.x, fy: node.y} : {fx: fix[0], fy: fix[1]}"
                 },
                 {
-                "trigger": "!fix",
-                "modify": "node", "values": "{fx: null, fy: null}"
+                    "trigger": "!fix",
+                    "modify": "node", "values": "{fx: null, fy: null}"
                 }
             ],
 
             "encode": {
-                "enter": {
-                "fill": {"scale": "color", "field": "group"},
-                "stroke": {"value": "white"}
+                    "enter": {
+                    "fill": {"scale": "color", "field": "group"},
+                    "stroke": {"value": "white"}
                 },
                 "update": {
-                "size": {"signal": "2 * nodeRadius * nodeRadius"},
-                "cursor": {"value": "pointer"}
+                    "size": {"signal": "2 * nodeRadius * nodeRadius"},
+                    "cursor": {"value": "pointer"}
                 }
             },
 
             "transform": [
                 {
-                "type": "force",
-                "iterations": 300,
-                "restart": {"signal": "restart"},
-                "static": {"signal": "static"},
-                "signal": "force",
-                "forces": [
-                    {"force": "center", "x": {"signal": "cx"}, "y": {"signal": "cy"}},
-                    {"force": "collide", "radius": {"signal": "nodeRadius"}},
-                    {"force": "nbody", "strength": {"signal": "nodeCharge"}},
-                    {"force": "link", "links": "link-data", "distance": {"signal": "linkDistance"}}
-                ]
+                    "type": "force",
+                    "iterations": 300,
+                    "restart": {"signal": "restart"},
+                    "static": {"signal": "static"},
+                    "signal": "force",
+                    "forces": [
+                        {"force": "center", "x": {"signal": "cx"}, "y": {"signal": "cy"}},
+                        {"force": "collide", "radius": {"signal": "nodeRadius"}},
+                        {"force": "nbody", "strength": {"signal": "nodeCharge"}},
+                        {"force": "link", "links": "link-data", "distance": {"signal": "linkDistance"}}
+                    ]
                 }
             ]
             },
@@ -203,17 +203,17 @@ def _graph_vega_doc(nodes, links):
             "interactive": False,
             "encode": {
                 "update": {
-                "stroke": {"value": "#ccc"},
-                "strokeWidth": {"value": 0.5}
+                    "stroke": {"value": "#ccc"},
+                    "strokeWidth": {"value": 0.5}
                 }
             },
             "transform": [
                 {
-                "type": "linkpath",
-                "require": {"signal": "force"},
-                "shape": "line",
-                "sourceX": "datum.source.x", "sourceY": "datum.source.y",
-                "targetX": "datum.target.x", "targetY": "datum.target.y"
+                    "type": "linkpath",
+                    "require": {"signal": "force"},
+                    "shape": "line",
+                    "sourceX": "datum.source.x", "sourceY": "datum.source.y",
+                    "targetX": "datum.target.x", "targetY": "datum.target.y"
                 }
             ]
             }

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -1,0 +1,49 @@
+from addcorpus.python_corpora.load_corpus import load_corpus_definition
+from wordmodels.utils import load_word_models
+from wordmodels.similarity import find_n_most_similar, term_similarity
+
+
+def local_graph_data(corpus_name: str, query_term: str):
+    corpus = load_corpus_definition(corpus_name)
+    wm_list = load_word_models(corpus)
+
+    return [
+        {
+            'start_year': wm['start_year'],
+            'end_year': wm['end_year'],
+            'data': local_graph_in_timeframe(wm, query_term)
+        }
+        for wm in wm_list
+    ]
+
+
+def local_graph_in_timeframe(wm, query_term: str):
+    nodes = _graph_nodes(wm, query_term)
+    links = _graph_links(wm, nodes)
+
+    return {
+        'nodes': nodes,
+        'links': links
+    }
+
+
+def _graph_nodes(wm, query_term):
+    neighbours = find_n_most_similar(wm, query_term, 5)
+    query_node = {
+        'term': query_term,
+        'index': 0,
+        'similarity': 1,
+    }
+    neighbour_nodes = (
+        {
+            'term': item['key'],
+            'index': i + 1,
+            'similarity': item['similarity'],
+        }
+        for (i, item) in enumerate(neighbours)
+    )
+    return [query_node, *neighbour_nodes]
+
+
+def _graph_links(wm, nodes):
+    return []

--- a/backend/wordmodels/local_graph.py
+++ b/backend/wordmodels/local_graph.py
@@ -198,24 +198,39 @@ def _graph_vega_doc(nodes, links):
             ]
             },
             {
-            "type": "path",
-            "from": {"data": "link-data"},
-            "interactive": False,
-            "encode": {
-                "update": {
-                    "stroke": {"value": "#ccc"},
-                    "strokeWidth": {"value": 0.5}
-                }
+                "type": "path",
+                "from": {"data": "link-data"},
+                "interactive": False,
+                "encode": {
+                    "update": {
+                        "stroke": {"value": "#ccc"},
+                        "strokeWidth": {"value": 0.5}
+                    }
+                },
+                "transform": [
+                    {
+                        "type": "linkpath",
+                        "require": {"signal": "force"},
+                        "shape": "line",
+                        "sourceX": "datum.source.x", "sourceY": "datum.source.y",
+                        "targetX": "datum.target.x", "targetY": "datum.target.y"
+                    }
+                ]
             },
-            "transform": [
-                {
-                    "type": "linkpath",
-                    "require": {"signal": "force"},
-                    "shape": "line",
-                    "sourceX": "datum.source.x", "sourceY": "datum.source.y",
-                    "targetX": "datum.target.x", "targetY": "datum.target.y"
-                }
-            ]
-            }
+            {
+                "type": "text",
+                "from": {"data": "nodes"},
+                "zindex": 2,
+                "encode": {
+                    "enter": {
+                        "fontSize": {"value": 15},
+                        "fill": {"value": "black"},
+                        "text": {"field": "datum.term"},
+                        "baseline": {"value": "bottom"},
+                        "align": {"value": "center"}
+                    },
+                    "update": {"dx": {"field": "x"}, "dy": {"field": "y"}}
+                },
+            },
         ]
     }

--- a/backend/wordmodels/tests/test_wordmodels_views.py
+++ b/backend/wordmodels/tests/test_wordmodels_views.py
@@ -50,3 +50,16 @@ def test_word_in_models_view(term, in_model, admin_client, mock_corpus):
     else:
         assert data['exists'] == False
         assert 'similar_keys' in data
+
+
+def test_local_graph_view(admin_client, mock_corpus):
+    query_json = {
+        'query_term': 'alice',
+        'corpus_name': mock_corpus,
+    }
+    response = admin_client.post(
+        '/api/wordmodels/local_graph',
+        query_json,
+        content_type='application/json'
+    )
+    assert response.status_code == 200

--- a/backend/wordmodels/urls.py
+++ b/backend/wordmodels/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('related_words', RelatedWordsView.as_view()),
     path('similarity_over_time', SimilarityView.as_view()),
     path('word_in_models', WordInModelView.as_view()),
+    path('local_graph', LocalGraphView.as_view()),
 ]

--- a/backend/wordmodels/utils.py
+++ b/backend/wordmodels/utils.py
@@ -44,6 +44,11 @@ def word_in_models(query_term, corpus, max_distance=2):
         'similar_keys': similar_keys
     }
 
+
+def word_in_model(query_term, wm):
+    return query_term in wm['vectors']
+
+
 def transform_query(query):
     if not has_whitespace(query):
         transformed = strip_punctuation(query).lower()

--- a/backend/wordmodels/views.py
+++ b/backend/wordmodels/views.py
@@ -28,6 +28,18 @@ class RelatedWordsView(APIView):
                     'time_points': results[1]
             })
 
+
+class LocalGraphView(APIView):
+    '''
+    Get a graph of the nearest neighbours of the query term
+    '''
+
+    permission_classes = [CanSearchCorpus]
+
+    def post(self, request, *args, **kwargs):
+        return Response({})
+
+
 class SimilarityView(APIView):
     '''
     Get similarity between two query terms

--- a/backend/wordmodels/views.py
+++ b/backend/wordmodels/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from addcorpus.permissions import CanSearchCorpus, corpus_name_from_request
 from wordmodels import utils, visualisations
 from rest_framework.exceptions import APIException
+from wordmodels import local_graph
 
 class RelatedWordsView(APIView):
     '''
@@ -37,7 +38,10 @@ class LocalGraphView(APIView):
     permission_classes = [CanSearchCorpus]
 
     def post(self, request, *args, **kwargs):
-        return Response({})
+        corpus = corpus_name_from_request(request)
+        query_term = request.data['query_term']
+        results = local_graph.local_graph_data(corpus, query_term)
+        return Response(results)
 
 
 class SimilarityView(APIView):

--- a/frontend/src/app/services/wordmodels.service.ts
+++ b/frontend/src/app/services/wordmodels.service.ts
@@ -57,6 +57,18 @@ export class WordmodelsService {
         });
     }
 
+    public getLocalGraph(
+        queryTerm: string,
+        corpusName: string,
+        neighbours: number,
+    ) {
+        return this.http.post(this.wmApiRoute('local_graph'), {
+            query_term: queryTerm,
+            corpus_name: corpusName,
+            neighbours,
+        });
+    }
+
     public async getWordSimilarity(
         term1: string,
         term2: string,

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,1 +1,1 @@
-<p>local-graph works!</p>
+<pre>{{data | json}}</pre>

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,1 +1,1 @@
-<pre>{{data | json}}</pre>
+<div #chart></div>

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,5 +1,5 @@
 <div class="block">
-    <div #chart  [class.is-hidden]="asTable" [attr.aria-hidden]="asTable"></div>
+    <div #chart id="chart" [class.is-hidden]="asTable" [attr.aria-hidden]="asTable"></div>
 
     <ia-freqtable [headers]="tableHeaders" [data]="data?.table"
         [class.is-hidden]="!asTable" [attr.aria-hidden]="!asTable" />

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,0 +1,1 @@
+<p>local-graph works!</p>

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,1 +1,16 @@
-<div #chart></div>
+<div class="field">
+
+    <p class="label">Select timeframe:</p>
+
+    <div class="block">
+        <button *ngFor="let interval of timeIntervals; index as i" class="button"
+            [class.is-primary]="isSelected(i)" [aria-pressed]="isSelected(i)"
+            (click)="selectInterval(i)">
+            {{interval}}
+        </button>
+    </div>
+</div>
+
+<div class="block">
+    <div #chart></div>
+</div>

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,16 +1,3 @@
-<div class="field">
-
-    <p class="label">Select timeframe:</p>
-
-    <div class="block">
-        <button *ngFor="let interval of timeIntervals; index as i" class="button"
-            [class.is-primary]="isSelected(i)" [aria-pressed]="isSelected(i)"
-            (click)="selectInterval(i)">
-            {{interval}}
-        </button>
-    </div>
-</div>
-
 <div class="block">
     <div #chart></div>
 </div>

--- a/frontend/src/app/word-models/local-graph/local-graph.component.html
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.html
@@ -1,3 +1,6 @@
 <div class="block">
-    <div #chart></div>
+    <div #chart  [class.is-hidden]="asTable" [attr.aria-hidden]="asTable"></div>
+
+    <ia-freqtable [headers]="tableHeaders" [data]="data?.table"
+        [class.is-hidden]="!asTable" [attr.aria-hidden]="!asTable" />
 </div>

--- a/frontend/src/app/word-models/local-graph/local-graph.component.spec.ts
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LocalGraphComponent } from './local-graph.component';
+
+describe('LocalGraphComponent', () => {
+    let component: LocalGraphComponent;
+    let fixture: ComponentFixture<LocalGraphComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [LocalGraphComponent]
+        })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(LocalGraphComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/frontend/src/app/word-models/local-graph/local-graph.component.ts
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'ia-local-graph',
+    templateUrl: './local-graph.component.html',
+    styleUrl: './local-graph.component.scss'
+})
+export class LocalGraphComponent {
+
+}

--- a/frontend/src/app/word-models/local-graph/local-graph.component.ts
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { Corpus } from '@models';
 import { WordmodelsService } from '@services';
+import { BehaviorSubject } from 'rxjs';
 import embed from 'vega-embed';
 
 @Component({
@@ -15,6 +16,9 @@ export class LocalGraphComponent implements OnChanges {
     @ViewChild('chart') chart!: ElementRef;
 
     data: any;
+
+    timeIntervals: string[];
+    interval$ = new BehaviorSubject<number>(0);
 
     constructor(
         private wordModelsService: WordmodelsService,
@@ -32,9 +36,20 @@ export class LocalGraphComponent implements OnChanges {
 
     onDataLoaded(res) {
         this.data = res;
-        const spec = res[0]['graph'];
-        console.log(spec);
+        this.timeIntervals = this.data.map(bin =>
+            `${bin.start_year}-${bin.end_year}`
+        );
+        this.selectInterval(0);
+    }
+
+    selectInterval(i: number): void {
+        this.interval$.next(i);
+        const spec = this.data[i]['graph'];
         this.renderChart(spec);
+    }
+
+    isSelected(i: number): boolean {
+        return this.interval$.value === i;
     }
 
     renderChart(data): void {

--- a/frontend/src/app/word-models/local-graph/local-graph.component.ts
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.ts
@@ -1,10 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Corpus } from '@models';
+import { WordmodelsService } from '@services';
 
 @Component({
     selector: 'ia-local-graph',
     templateUrl: './local-graph.component.html',
     styleUrl: './local-graph.component.scss'
 })
-export class LocalGraphComponent {
+export class LocalGraphComponent implements OnChanges {
+    @Input({required: true}) corpus!: Corpus;
+    @Input({required: true}) queryText!: string;
 
+    data: any;
+
+    constructor(
+        private wordModelsService: WordmodelsService,
+    ) { }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        this.getData()
+    }
+
+    getData() {
+        this.wordModelsService.getLocalGraph(
+            this.queryText, this.corpus.name, 5
+        ).subscribe(res => this.data = res);
+    }
 }

--- a/frontend/src/app/word-models/local-graph/local-graph.component.ts
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.ts
@@ -17,8 +17,6 @@ export class LocalGraphComponent implements OnChanges {
 
     data: any;
 
-    timeIntervals: string[];
-    interval$ = new BehaviorSubject<number>(0);
 
     constructor(
         private wordModelsService: WordmodelsService,
@@ -36,20 +34,7 @@ export class LocalGraphComponent implements OnChanges {
 
     onDataLoaded(res) {
         this.data = res;
-        this.timeIntervals = this.data.map(bin =>
-            `${bin.start_year}-${bin.end_year}`
-        );
-        this.selectInterval(0);
-    }
-
-    selectInterval(i: number): void {
-        this.interval$.next(i);
-        const spec = this.data[i]['graph'];
-        this.renderChart(spec);
-    }
-
-    isSelected(i: number): boolean {
-        return this.interval$.value === i;
+        this.renderChart(res['graph']);
     }
 
     renderChart(data): void {

--- a/frontend/src/app/word-models/local-graph/local-graph.component.ts
+++ b/frontend/src/app/word-models/local-graph/local-graph.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
-import { Corpus } from '@models';
+import { Corpus, FreqTableHeaders } from '@models';
 import { WordmodelsService } from '@services';
 import { BehaviorSubject } from 'rxjs';
 import embed from 'vega-embed';
@@ -12,11 +12,30 @@ import embed from 'vega-embed';
 export class LocalGraphComponent implements OnChanges {
     @Input({required: true}) corpus!: Corpus;
     @Input({required: true}) queryText!: string;
+    @Input() asTable: boolean;
 
     @ViewChild('chart') chart!: ElementRef;
 
     data: any;
 
+    tableHeaders: FreqTableHeaders = [
+        {
+            key: 'term1',
+            label: 'Term 1',
+        },
+        {
+            key: 'term2',
+            label: 'Term 2',
+        },
+        {
+            key: 'timeframe',
+            label: 'Timeframe',
+        },
+        {
+            key: 'similarity',
+            label: 'Similarity'
+        }
+    ]
 
     constructor(
         private wordModelsService: WordmodelsService,

--- a/frontend/src/app/word-models/word-models.component.html
+++ b/frontend/src/app/word-models/word-models.component.html
@@ -67,6 +67,8 @@
                                 [asTable]="asTable" [palette]="palette"
                                 (wordSimilarityError)="setErrorMessage($event)">
                             </ia-word-similarity>
+
+                            <ia-local-graph *ngIf="tab=='localgraph'"/>
                         </div>
 
                         <div class="block">

--- a/frontend/src/app/word-models/word-models.component.html
+++ b/frontend/src/app/word-models/word-models.component.html
@@ -68,7 +68,9 @@
                                 (wordSimilarityError)="setErrorMessage($event)">
                             </ia-word-similarity>
 
-                            <ia-local-graph *ngIf="tab=='localgraph'"/>
+                            <ia-local-graph *ngIf="tab=='localgraph'"
+                                [corpus]="corpus" [queryText]="activeQuery"
+                                />
                         </div>
 
                         <div class="block">

--- a/frontend/src/app/word-models/word-models.component.html
+++ b/frontend/src/app/word-models/word-models.component.html
@@ -70,6 +70,7 @@
 
                             <ia-local-graph *ngIf="tab=='localgraph'"
                                 [corpus]="corpus" [queryText]="activeQuery"
+                                [asTable]="asTable"
                                 />
                         </div>
 

--- a/frontend/src/app/word-models/word-models.component.ts
+++ b/frontend/src/app/word-models/word-models.component.ts
@@ -39,6 +39,11 @@ export class WordModelsComponent extends ParamDirective {
             manual: 'relatedwords',
             chartID: 'chart',
         },
+        localgraph: {
+            title: 'Local graph',
+            manual: 'localgraph',
+            chartID: 'chart',
+        },
         wordsimilarity: {
             title: 'Compare similarity',
             manual: 'comparesimilarity',

--- a/frontend/src/app/word-models/word-models.component.ts
+++ b/frontend/src/app/word-models/word-models.component.ts
@@ -41,7 +41,7 @@ export class WordModelsComponent extends ParamDirective {
         },
         localgraph: {
             title: 'Local graph',
-            manual: 'localgraph',
+            manual: 'local-graph',
             chartID: 'chart',
         },
         wordsimilarity: {

--- a/frontend/src/app/word-models/word-models.module.ts
+++ b/frontend/src/app/word-models/word-models.module.ts
@@ -9,6 +9,7 @@ import { SimilarityChartComponent } from './similarity-chart/similarity-chart.co
 import { TimeIntervalSliderComponent } from './similarity-chart/time-interval-slider/time-interval-slider.component';
 import { WordModelsComponent } from './word-models.component';
 import { WordSimilarityComponent } from './word-similarity/word-similarity.component';
+import { LocalGraphComponent } from './local-graph/local-graph.component';
 
 
 @NgModule({
@@ -22,6 +23,7 @@ import { WordSimilarityComponent } from './word-similarity/word-similarity.compo
         WordSimilarityComponent,
         SimilarityChartComponent,
         TimeIntervalSliderComponent,
+        LocalGraphComponent,
     ], exports: [
         WordModelsComponent,
     ],
@@ -29,6 +31,6 @@ import { WordSimilarityComponent } from './word-similarity/word-similarity.compo
         CorpusModule,
         SharedModule,
         VisualizationModule,
-    ]
+    ],
 })
 export class WordModelsModule { }

--- a/frontend/src/assets/manual/en-GB/local-graph.md
+++ b/frontend/src/assets/manual/en-GB/local-graph.md
@@ -1,0 +1,24 @@
+This graph shows words that appear in the same contexts as the query term across the corpus.
+
+## Word models
+
+The similarity scores are based on [word embeddings](https://en.wikipedia.org/wiki/Word_embedding). The algorithm to compute these embeddings depends on the corpus, and is described in the corpus documentation (click 'models' at the top of the page).
+
+For each corpus that includes word embeddings, we have trained a model of the complete corpus, and separate models for consecutive time frames. Thus, we can compute the overall similarity between terms, and say how this similarity develops over time.
+
+If words appear in the same context, their vectors are more alike, which is reflected in a higher cosine similarity. Words that appear in the same context are likely to have related meanings: you can think of synonyms like `big` and `large`, but also antonyms like `black` and `white`, or simply words that are associated with the same topic, like `bank` and `financial`.
+
+## Graph data
+
+The graph shows the relations between the query term and its closests neighbours. These are the terms that have the highest similarity to the query term.
+
+The neighbours of a word are not always similar to one another. For example, you might search for `bank` and find that `financial`, `river`, and `loan` are closely related. `financial` and `loan` are also highly similar to each other, but `river` is not similar to `financial`or `loan`.
+
+The graph shows these connections. A link is drawn between terms that are similar to one another; they must be at least as similar as the target term and the lowest-ranking term in the graph. Links are drawn in a darker color if the similarity is higher.
+
+## Controls
+
+- The graph always shows data from a single timeframe at a time. You can use the "time frame" selection to choose the period.
+- "link distance" controls how spread out terms in the graph are.
+- "static" controls whether the force simulation in the graph (which tries to position nodes) is static or animated.
+- You can click and drag on words in the graph to reposition them.

--- a/frontend/src/assets/manual/en-GB/manifest.json
+++ b/frontend/src/assets/manual/en-GB/manifest.json
@@ -52,6 +52,10 @@
                 "title": "Related words"
             },
             {
+                "id": "local-graph",
+                "title": "Local graph"
+            },
+            {
                 "id": "comparesimilarity",
                 "title": "Compare similarity"
             }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -103,3 +103,22 @@ a.dropdown-item[disabled] {
 .is-disabled {
     @extend [disabled];
 }
+
+.vega-bindings {
+    @extend .columns;
+    @extend .is-multiline;
+
+    .vega-bind {
+        @extend .field;
+        @extend .column;
+        @extend .is-4;
+
+        .vega-bind-name {
+            @extend .label;
+        }
+
+        select {
+            @extend .select;
+        }
+    }
+}


### PR DESCRIPTION
This implements https://github.com/CentreForDigitalHumanities/I-analyzer/discussions/1434. It adds a visualisation to the word models page where you can see a network of a term's nearest neighbours (based on similarity). Screenshot:

![screenshot of I-analyzer, showing a network of words](https://github.com/user-attachments/assets/c0253015-3baf-4def-b86f-5951d8f49481)

The graph could use some extra polishing but it is in a presentable state, with a table view, manual page, etc.

No direct reason to make this now, other than that I felt like playing around with it.