### PR TITLE
Corpus documentation in JSON definition

### DIFF
--- a/backend/addcorpus/json_corpora/export_json.py
+++ b/backend/addcorpus/json_corpora/export_json.py
@@ -14,6 +14,9 @@ def export_json_corpus(corpus: Corpus) -> Dict:
     data['fields'] = [
         export_json_field(field) for field in config.fields.all()
     ]
+    documentation = export_corpus_documentation(config)
+    if documentation:
+        data['documentation'] = documentation
     return data
 
 def export_corpus_meta(configuration: CorpusConfiguration) -> Dict:
@@ -90,3 +93,12 @@ def export_field_filter(field: Field) -> str:
 
 def export_field_extract(field: Field) -> Dict:
     return {'column': field.extract_column}
+
+
+def export_corpus_documentation(config: CorpusConfiguration):
+    pages = config.documentation_pages.all()
+
+    if pages.exists():
+        return {page.type: page.content for page in pages}
+    else:
+        return None

--- a/backend/addcorpus/json_corpora/import_json.py
+++ b/backend/addcorpus/json_corpora/import_json.py
@@ -40,6 +40,7 @@ def _parse_configuration(data: Dict) -> Dict:
         'source_data_delimiter': get_path(
             data, 'source_data', 'options', 'delimiter') or DEFAULT_CSV_DELIMITER,
         'fields': _import_fields(data),
+        'documentation_pages': _import_documentation(data)
     }
 
 
@@ -269,3 +270,14 @@ def _include_ngram_visualisation(fields: Iterable[Dict]) -> None:
         for field in fields:
             if field['display_type'] == 'text_content':
                 field['visualizations'].append(VisualizationType.NGRAM.value)
+
+
+def _import_documentation(data: Dict):
+    docs = get_path(data, 'documentation') or {}
+    return [
+        {
+            'type': key,
+            'content': content,
+        }
+        for (key, content) in docs.items()
+    ]

--- a/backend/addcorpus/schemas/corpus.schema.json
+++ b/backend/addcorpus/schemas/corpus.schema.json
@@ -228,10 +228,6 @@
             "license": {
                 "type": "string",
                 "description": "License for re-use"
-            },
-            "terms_of_service": {
-                "type": "string",
-                "description": "Terms of service"
             }
         }
     },

--- a/backend/addcorpus/schemas/corpus.schema.json
+++ b/backend/addcorpus/schemas/corpus.schema.json
@@ -213,6 +213,28 @@
             }
         }
     },
+    "documentation": {
+        "type": "object",
+        "description": "Documentation pages",
+        "properties": {
+            "general": {
+                "type": "string",
+                "description": "General information about the corpus"
+            },
+            "citation": {
+                "type": "string",
+                "description": "Citation guidelines"
+            },
+            "license": {
+                "type": "string",
+                "description": "License for re-use"
+            },
+            "terms_of_service": {
+                "type": "string",
+                "description": "Terms of service"
+            }
+        }
+    },
     "required": ["name", "meta", "source_data", "fields"],
     "$defs": {
         "sortSetting": {

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -136,7 +136,6 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
     type = PrettyChoiceField(choices = CorpusDocumentationPage.PageType.choices)
     index = serializers.IntegerField(source='page_index', read_only=True)
     content = DocumentationTemplateField(read_only=True)
-    content_template = serializers.CharField(source='content')
     corpus = serializers.SlugRelatedField(
         source='corpus_configuration',
         queryset=CorpusConfiguration.objects.all(),
@@ -145,7 +144,7 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CorpusDocumentationPage
-        fields = ['id', 'corpus', 'type', 'content', 'content_template', 'index']
+        fields = ['id', 'corpus', 'type', 'content', 'index']
 
 
 class JSONDefinitionField(serializers.Field):

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -75,20 +75,6 @@ def test_corpus_documentation_retrieve_view(admin_client: Client):
     assert status.is_success(response.status_code)
 
 
-def test_corpus_documentation_create_view(admin_client, basic_mock_corpus):
-    request_data = {
-        'corpus': basic_mock_corpus,
-        'type': 'Terms of service',
-        'content_template': 'You can do whatever you want.'
-    }
-    response = admin_client.post(
-        '/api/corpus/documentation/',
-        request_data,
-        content_type='application/json'
-    )
-    assert status.is_success(response.status_code)
-
-
 def test_corpus_image_view(admin_client, basic_mock_corpus):
     corpus = Corpus.objects.get(name=basic_mock_corpus)
     assert not corpus.configuration.image

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -36,7 +36,7 @@ class CorpusView(viewsets.ReadOnlyModelViewSet):
         return searchable_corpora(self.request.user).order_by('-date_created')
 
 
-class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
+class CorpusDocumentationPageViewset(viewsets.ReadOnlyModelViewSet):
     '''
     Markdown documentation pages for corpora.
     '''
@@ -49,8 +49,7 @@ class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
 
 
     def get_queryset(self):
-        condition = searchable_condition(self.request.user) | \
-            editable_condition(self.request.user)
+        condition = searchable_condition(self.request.user)
 
         queried_corpus = self.request.query_params.get('corpus')
         if queried_corpus:

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
@@ -7,25 +7,24 @@
     <a href="https://www.markdownguide.org/">markdown</a> to style the content.
 </p>
 
-<form>
+<form [formGroup]="form" (ngSubmit)="submit()">
     <div class="block">
         <ia-tabs>
-            <ng-template iaTabPanel *ngFor="let page of pages"
-                 [id]="page.category.id" [title]="page.category.title">
+            <ng-template iaTabPanel *ngFor="let category of categories"
+                 [id]="category.id" [title]="category.title">
 
-                <p class="block">{{page.category.description}}</p>
+                <p class="block">{{category.description}}</p>
 
-                <textarea [(ngModel)]="page.content"
-                    [name]="page.category.id"
+                <textarea [formControl]="form.controls[category.id]"
                     class="textarea" rows="10"
-                    [attr.aria-labelledby]="'tab-' + page.category.id">
+                    [attr.aria-labelledby]="'tab-' + category.id">
                 </textarea>
             </ng-template>
         </ia-tabs>
     </div>
 
     <div class="block">
-        <button class="button is-primary" type="submit" (click)="submit()">
+        <button class="button is-primary" type="submit">
             Save changes
         </button>
     </div>

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
@@ -3,6 +3,9 @@ import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definitio
 import * as _ from 'lodash';
 import { EditablePage, makePages, PAGE_CATEGORIES } from './editable-page';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup } from '@angular/forms';
+import { filter, map, switchMap } from 'rxjs';
+import { APICorpusDefinition } from '@models/corpus-definition';
 
 
 @Component({
@@ -11,13 +14,13 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     styleUrl: './documentation-form.component.scss'
 })
 export class DocumentationFormComponent implements OnInit {
-    documentation$ = this.corpusDefService.documentation$;
+    form = new FormGroup({
+        general: new FormControl<string>(''),
+        citation: new FormControl<string>(''),
+        license: new FormControl<string>(''),
+    });
 
     categories = PAGE_CATEGORIES;
-
-    pages: EditablePage[] = makePages(
-        this.corpusDefService.corpus$.value.definition.name
-    );
 
     constructor(
         private corpusDefService: CorpusDefinitionService,
@@ -25,16 +28,32 @@ export class DocumentationFormComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        this.documentation$.pipe(
+        this.corpusDefService.corpus$.pipe(
+            switchMap(corpus => corpus.definitionUpdated$),
+            map(() => this.corpusDefService.corpus$.value.definition),
+            filter(definition => !!definition),
             takeUntilDestroyed(this.destroyRef),
-        ).subscribe(
-            data => this.pages.forEach(page =>
-                this.corpusDefService.updateDocumentationPage(page, data)
-            )
-        );
+        ).subscribe({
+            next: (value) => this.updateForm(value),
+        });
+    }
+
+    updateForm(value: APICorpusDefinition) {
+        this.form.setValue({
+            general: value.documentation?.general || '',
+            citation: value.documentation?.citation || '',
+            license: value.documentation?.license || '',
+        });
     }
 
     submit() {
-        this.corpusDefService.saveDocumentationPages(this.pages).subscribe();
+        const corpus = this.corpusDefService.corpus$.value;
+        const values = _.values(this.form.controls).map(control => control.value);
+        if (_.every(values, _.isEmpty)) {
+            corpus.definition = _.omit(corpus.definition, 'documentation');
+        } else {
+            corpus.definition.documentation = _.omitBy(this.form.value, _.isEmpty);
+        }
+        corpus.save();
     }
 }

--- a/frontend/src/app/corpus-definitions/form/documentation-form/editable-page.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/editable-page.ts
@@ -20,12 +20,6 @@ export const PAGE_CATEGORIES: DocumentationCategory[] = [
         title: 'License',
         description: 'We recommend providing a licence for others to reuse the data in your corpus, if possible.',
     },
-    {
-        id: 'terms_of_service',
-        title: 'Terms of service',
-        description: 'Does your corpus require additional conditions for users?',
-    },
-    // does not include the word models page; db-only corpora don't support word models
 ];
 
 export class EditablePage {

--- a/frontend/src/app/models/corpus-definition.ts
+++ b/frontend/src/app/models/corpus-definition.ts
@@ -78,6 +78,11 @@ export interface APICorpusDefinition {
             ascending: boolean;
         };
     };
+    documentation?: {
+        general?: string,
+        citation?: string,
+        license?: string,
+    }
 }
 
 export interface APIEditableCorpus {

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -146,12 +146,6 @@ export interface CorpusDocumentationPage {
     corpus: string;
     type: string;
     content: string;
-    content_template: string,
-    index?: number;
+    index: number;
 }
 
-export interface CorpusDocumentationPageSubmitData {
-    type: string,
-    corpus: string,
-    content_template: string,
-};

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -9,7 +9,6 @@ import {
     AggregateTermFrequencyParameters,
     Corpus,
     CorpusDocumentationPage,
-    CorpusDocumentationPageSubmitData,
     DateTermFrequencyParameters,
     DocumentTagsResponse,
     Download,
@@ -255,21 +254,6 @@ export class ApiService {
             `documentation/${pageID}/`
         );
         return this.http.get<CorpusDocumentationPage>(url);
-    }
-
-    public createCorpusDocumentationPage(data: CorpusDocumentationPageSubmitData) {
-        const url = this.apiRoute(this.corpusApiUrl, 'documentation/');
-        return this.http.post(url, data);
-    }
-
-    public updateCorpusDocumentationPage(pageID: number, data: CorpusDocumentationPageSubmitData) {
-        const url = this.apiRoute(this.corpusApiUrl, `documentation/${pageID}/`);
-        return this.http.put(url, data);
-    }
-
-    public deleteCorpusDocumentationPage(pageID: number) {
-        const url = this.apiRoute(this.corpusApiUrl, `documentation/${pageID}/`);
-        return this.http.delete(url);
     }
 
     /** fetch a list of all corpora available for searching */


### PR DESCRIPTION
Changes the API to edit corpus documentation. Documentation is now included in the JSON definition for the corpus.

Motivation:

- It was confusing that the corpus download/upload function did not include the documentation.
- Simplifies the logic in the frontend (no separate endpoints for editing documentation)
- I had tried moving the metadata form, image upload and documentation editor to a single page. I think this makes sense, but I ran into a conflict because the metadata form allows you to change the corpus name, but the documentation API depends on the corpus name, which made everything way too complicated.

Also, it used to be that the user could edit `general`, `citation`, `license`, and `terms_of_service`, but not `wordmodels` (because they can't upload models in the form). I also removed `terms_of_service` here, because a) it's a bit unclear what this could even be, and b) unlike citation guidelines and a licence, I don't really want to invite users to come up with ToS.