### PR TITLE
Feature/steps logic

### DIFF
--- a/frontend/src/app/corpus-definitions/corpus-definition.service.ts
+++ b/frontend/src/app/corpus-definitions/corpus-definition.service.ts
@@ -20,7 +20,6 @@ export class CorpusDefinitionService implements OnDestroy {
         { label: 'Corpus information' },
         { label: 'Upload source data' },
         { label: 'Define fields' },
-        { label: 'Add documentation' },
         { label: 'Process data' },
         { label: 'Browse your corpus' },
     ]);

--- a/frontend/src/app/corpus-definitions/corpus-definition.service.ts
+++ b/frontend/src/app/corpus-definitions/corpus-definition.service.ts
@@ -20,8 +20,7 @@ export class CorpusDefinitionService implements OnDestroy {
         { label: 'Corpus information' },
         { label: 'Upload source data' },
         { label: 'Define fields' },
-        { label: 'Process data' },
-        { label: 'Browse your corpus' },
+        { label: 'Index data' },
     ]);
     activeStep$ = new BehaviorSubject<number>(0);
 

--- a/frontend/src/app/corpus-definitions/corpus-definitions.module.ts
+++ b/frontend/src/app/corpus-definitions/corpus-definitions.module.ts
@@ -14,6 +14,7 @@ import { MultiSelectModule } from 'primeng/multiselect';
 import { DropdownModule } from 'primeng/dropdown';
 import { DocumentationFormComponent } from './form/documentation-form/documentation-form.component';
 import { ImageUploadComponent } from './form/image-upload/image-upload.component';
+import { FormFeedbackComponent } from './form/form-feedback/form-feedback.component';
 
 @NgModule({
     declarations: [
@@ -27,6 +28,7 @@ import { ImageUploadComponent } from './form/image-upload/image-upload.component
         UploadSampleComponent,
         DocumentationFormComponent,
         ImageUploadComponent,
+        FormFeedbackComponent,
     ],
     exports: [
         CreateDefinitionComponent,

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
@@ -21,6 +21,9 @@
             <ia-upload-sample *ngSwitchCase="1" />
             <ng-container *ngSwitchCase="2"><ia-field-form *ngIf="corpus$ | async as corpus"
                     [corpus]="corpus" /></ng-container>
+            <p *ngSwitchCase="3">
+                <i>Coming soon!</i>
+            </p>
         </div>
     </div>
 </ng-container>

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
@@ -21,7 +21,6 @@
             <ia-upload-sample *ngSwitchCase="1" />
             <ng-container *ngSwitchCase="2"><ia-field-form *ngIf="corpus$ | async as corpus"
                     [corpus]="corpus" /></ng-container>
-            <ia-documentation-form *ngSwitchCase="3" />
         </div>
     </div>
 </ng-container>

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.html
@@ -24,3 +24,12 @@
         </div>
     </div>
 </ng-container>
+
+<div class="section" *ngIf="nextStep$ | async as nextStep">
+    <div class="container is-readable">
+        <button class="button" (click)="toNext()" [disabled]="nextStep.disabled">
+            <span class="icon"><fa-icon [icon]="actionIcons.next" aria-hidden="true" /></span>
+            <span>{{nextStep.label}}</span>
+        </button>
+    </div>
+</div>

--- a/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/corpus-form/corpus-form.component.ts
@@ -4,8 +4,10 @@ import { CorpusDefinition } from '../../../models/corpus-definition';
 import { ApiService } from '../../../services';
 import { MenuItem } from 'primeng/api';
 import { CorpusDefinitionService } from '../../corpus-definition.service';
-import { tap } from 'rxjs';
+import { combineLatest, map, tap } from 'rxjs';
 import { cloneDeep } from 'lodash';
+import * as _ from 'lodash';
+import { actionIcons } from '@shared/icons';
 
 @Component({
     selector: 'ia-corpus-form',
@@ -17,7 +19,13 @@ export class CorpusFormComponent {
     steps$ = this.corpusDefService.steps$.asObservable();
     activeStep$ = this.corpusDefService.activeStep$.asObservable();
 
+    nextStep$ = combineLatest([this.steps$, this.activeStep$]).pipe(
+        map(([steps, current]) => _.nth(steps, current + 1)),
+    );
+
     corpus$ = this.corpusDefService.corpus$.asObservable();
+
+    actionIcons = actionIcons;
 
     constructor(
         private apiService: ApiService,
@@ -31,5 +39,9 @@ export class CorpusFormComponent {
 
     onActiveIndexChange(event: number) {
         this.corpusDefService.activateStep(event);
+    }
+
+    toNext() {
+        this.corpusDefService.activateStep(this.corpusDefService.activeStep$.value + 1);
     }
 }

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
@@ -22,8 +22,9 @@
     </div>
 
     <div class="block">
-        <button class="button is-primary" type="submit">
-            Save changes
+        <button class="button is-primary" type="submit" [class.is-loading]="loading$ | async">
+            <span class="icon"><fa-icon [icon]="formIcons.confirm" /></span>
+            <span>Save changes</span>
         </button>
     </div>
 

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
@@ -26,4 +26,18 @@
             Save changes
         </button>
     </div>
+
+    <div class="block" role="status">
+        <div class="message is-success" *ngIf="showSuccessMessage$ | async">
+            <p class="message-body">
+                Changes saved!
+            </p>
+        </div>
+        <div class="message is-danger" *ngIf="showErrorMessage$ | async">
+            <p class="message-body">
+                Something went wrong saving your changes. Please try again.
+                If you keep seeing this error, please contact support.
+            </p>
+        </div>
+    </div>
 </form>

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
@@ -27,17 +27,6 @@
         </button>
     </div>
 
-    <div class="block" role="status">
-        <div class="message is-success" *ngIf="showSuccessMessage$ | async">
-            <p class="message-body">
-                Changes saved!
-            </p>
-        </div>
-        <div class="message is-danger" *ngIf="showErrorMessage$ | async">
-            <p class="message-body">
-                Something went wrong saving your changes. Please try again.
-                If you keep seeing this error, please contact support.
-            </p>
-        </div>
-    </div>
+    <ia-form-feedback [showSuccess]="showSuccessMessage$ | async"
+        [showError]="showErrorMessage$ | async" />
 </form>

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.html
@@ -1,18 +1,16 @@
-<h1 class="title">Add documentation</h1>
-<p class="subtitle">Provide information about your corpus</p>
+<h2 class="title is-5">Documentation</h2>
+
 
 <p class="block">
     Add documentation to help users understand what your corpus is, and how they can use
     it in their research. You can use
     <a href="https://www.markdownguide.org/">markdown</a> to style the content.
 </p>
-
 <form [formGroup]="form" (ngSubmit)="submit()">
     <div class="block">
         <ia-tabs>
             <ng-template iaTabPanel *ngFor="let category of categories"
                  [id]="category.id" [title]="category.title">
-
                 <p class="block">{{category.description}}</p>
 
                 <textarea [formControl]="form.controls[category.id]"

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.spec.ts
@@ -7,6 +7,7 @@ import { ApiService } from '@services';
 import { ApiServiceMock } from 'mock-data/api';
 import { CorpusDefinition } from '@models/corpus-definition';
 import { ReactiveFormsModule } from '@angular/forms';
+import { FormFeedbackComponent } from '../form-feedback/form-feedback.component';
 
 describe('DocumentationFormComponent', () => {
     let component: DocumentationFormComponent;
@@ -14,7 +15,10 @@ describe('DocumentationFormComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [DocumentationFormComponent],
+            declarations: [
+                DocumentationFormComponent,
+                FormFeedbackComponent,
+            ],
             imports: [SharedModule, ReactiveFormsModule],
             providers: [
                 CorpusDefinitionService,

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
@@ -7,6 +7,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { filter, map, Observable, Subject, switchMap } from 'rxjs';
 import { APICorpusDefinition } from '@models/corpus-definition';
 import { mergeAsBooleans } from '@utils/observables';
+import { formIcons } from '@shared/icons';
 
 
 @Component({
@@ -42,6 +43,7 @@ export class DocumentationFormComponent implements OnInit {
         false: [this.changesSubmitted$, this.form.valueChanges]
     });
 
+    formIcons = formIcons;
 
     constructor(
         private corpusDefService: CorpusDefinitionService,

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
@@ -34,12 +34,12 @@ export class DocumentationFormComponent implements OnInit {
     });
     showSuccessMessage$: Observable<boolean> = mergeAsBooleans({
         true: [this.changesSavedSucces$],
-        false: [this.changesSubmitted$],
+        false: [this.changesSubmitted$, this.form.valueChanges],
     });
 
     showErrorMessage$: Observable<boolean> = mergeAsBooleans({
         true: [this.changesSavedError$],
-        false: [this.changesSubmitted$]
+        false: [this.changesSubmitted$, this.form.valueChanges]
     });
 
 

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
 import * as _ from 'lodash';
-import { EditablePage, makePages, PAGE_CATEGORIES } from './editable-page';
+import { PAGE_CATEGORIES } from './editable-page';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { filter, map, switchMap } from 'rxjs';

--- a/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/documentation-form/documentation-form.component.ts
@@ -4,8 +4,9 @@ import * as _ from 'lodash';
 import { PAGE_CATEGORIES } from './editable-page';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
-import { filter, map, switchMap } from 'rxjs';
+import { filter, map, Observable, Subject, switchMap } from 'rxjs';
 import { APICorpusDefinition } from '@models/corpus-definition';
+import { mergeAsBooleans } from '@utils/observables';
 
 
 @Component({
@@ -21,6 +22,26 @@ export class DocumentationFormComponent implements OnInit {
     });
 
     categories = PAGE_CATEGORIES;
+
+
+    changesSubmitted$ = new Subject<void>();
+    changesSavedSucces$ = new Subject<void>();
+    changesSavedError$ = new Subject<void>();
+
+    loading$: Observable<boolean> = mergeAsBooleans({
+        true: [this.changesSubmitted$],
+        false: [this.changesSavedSucces$, this.changesSavedError$],
+    });
+    showSuccessMessage$: Observable<boolean> = mergeAsBooleans({
+        true: [this.changesSavedSucces$],
+        false: [this.changesSubmitted$],
+    });
+
+    showErrorMessage$: Observable<boolean> = mergeAsBooleans({
+        true: [this.changesSavedError$],
+        false: [this.changesSubmitted$]
+    });
+
 
     constructor(
         private corpusDefService: CorpusDefinitionService,
@@ -54,6 +75,17 @@ export class DocumentationFormComponent implements OnInit {
         } else {
             corpus.definition.documentation = _.omitBy(this.form.value, _.isEmpty);
         }
-        corpus.save();
+        corpus.save().subscribe({
+            next: () => this.onSubmitSuccess(),
+            error: () => this.onSubmitError(),
+        });
+    }
+
+    private onSubmitSuccess() {
+        this.changesSavedSucces$.next();
+    }
+
+    private onSubmitError() {
+        this.changesSavedError$.next();
     }
 }

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -107,17 +107,11 @@
 
 
 
-    <div class="field is-grouped">
+    <div class="field">
         <div class="control">
             <button class="button is-primary" type="submit">
                 <span class="icon"><fa-icon [icon]="formIcons.confirm" /></span>
                 <span>Save changes</span>
-            </button>
-        </div>
-        <div class="control">
-            <button class="button" (click)="nextStep()">
-                <span class="icon"><fa-icon [icon]="actionIcons.next" /></span>
-                <span>Add documentation</span>
             </button>
         </div>
     </div>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -121,4 +121,18 @@
             </button>
         </div>
     </div>
+
+    <div class="block" role="status">
+        <div class="message is-success" *ngIf="showSuccesMessage$ | async">
+            <p class="message-body">
+                Changes saved!
+            </p>
+        </div>
+        <div class="message is-danger" *ngIf="showErrorMessage$ | async">
+            <p class="message-body">
+                Something went wrong saving your changes. Please try again.
+                If you keep seeing this error, please contact support.
+            </p>
+        </div>
+    </div>
 </form>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -116,17 +116,6 @@
         </div>
     </div>
 
-    <div class="block" role="status">
-        <div class="message is-success" *ngIf="showSuccesMessage$ | async">
-            <p class="message-body">
-                Changes saved!
-            </p>
-        </div>
-        <div class="message is-danger" *ngIf="showErrorMessage$ | async">
-            <p class="message-body">
-                Something went wrong saving your changes. Please try again.
-                If you keep seeing this error, please contact support.
-            </p>
-        </div>
-    </div>
+    <ia-form-feedback [showSuccess]="showSuccesMessage$ | async"
+        [showError]="showErrorMessage$ | async" />
 </form>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.html
@@ -107,9 +107,18 @@
 
 
 
-    <div class="field">
-        <p class="control">
-            <button class="button is-primary" type="submit">Save changes</button>
-        </p>
+    <div class="field is-grouped">
+        <div class="control">
+            <button class="button is-primary" type="submit">
+                <span class="icon"><fa-icon [icon]="formIcons.confirm" /></span>
+                <span>Save changes</span>
+            </button>
+        </div>
+        <div class="control">
+            <button class="button" (click)="nextStep()">
+                <span class="icon"><fa-icon [icon]="actionIcons.next" /></span>
+                <span>Add documentation</span>
+            </button>
+        </div>
     </div>
 </form>

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.spec.ts
@@ -4,6 +4,7 @@ import { FieldFormComponent } from './field-form.component';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
 import { SharedModule } from '@shared/shared.module';
 import { ReactiveFormsModule } from '@angular/forms';
+import { FormFeedbackComponent } from '../form-feedback/form-feedback.component';
 
 describe('FieldFormComponent', () => {
     let component: FieldFormComponent;
@@ -11,7 +12,10 @@ describe('FieldFormComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [FieldFormComponent],
+            declarations: [
+                FieldFormComponent,
+                FormFeedbackComponent,
+            ],
             imports: [SharedModule, ReactiveFormsModule],
             providers: [CorpusDefinitionService],
         }).compileComponents();

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -5,12 +5,13 @@ import {
     CorpusDefinition,
 } from '@models/corpus-definition';
 import { MenuItem } from 'primeng/api';
-import { map, merge, Observable, Subject, takeUntil } from 'rxjs';
+import { Observable, Subject, takeUntil } from 'rxjs';
 import * as _ from 'lodash';
 
 import { ISO6393Languages } from '../constants';
 import { actionIcons, directionIcons, formIcons } from '@shared/icons';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
+import { mergeAsBooleans } from '@utils/observables';
 
 @Component({
     selector: 'ia-field-form',
@@ -64,29 +65,14 @@ export class FieldFormComponent {
     /** show succes message after success response, hide when form is changed or user
      * saves again
      */
-    showSuccesMessage$: Observable<boolean> = merge(
-        this.changesSavedSucces$.pipe(
-            map(() => true),
-        ),
-        this.valueChange$.pipe(
-            map(() => false),
-        ),
-        this.changesSubmitted$.pipe(
-            map(() => false),
-        )
-    );
-
-    showErrorMessage$: Observable<boolean> = merge(
-        this.changesSavedError$.pipe(
-            map(() => true),
-        ),
-        this.valueChange$.pipe(
-            map(() => false),
-        ),
-        this.changesSubmitted$.pipe(
-            map(() => false),
-        )
-    );
+    showSuccesMessage$: Observable<boolean> = mergeAsBooleans({
+        true: [this.changesSavedSucces$],
+        false: [this.valueChange$, this.changesSubmitted$],
+    });
+    showErrorMessage$: Observable<boolean> = mergeAsBooleans({
+        true: [this.changesSavedError$],
+        false: [this.valueChange$, this.changesSubmitted$],
+    });
 
     constructor(
         private el: ElementRef<HTMLElement>,

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -178,8 +178,4 @@ export class FieldFormComponent {
         const button = this.el.nativeElement.querySelector<HTMLButtonElement>(selector);
         button.focus();
     }
-
-    nextStep() {
-        this.corpusDefService.activateStep(3);
-    }
 }

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -9,7 +9,8 @@ import { Subject, takeUntil } from 'rxjs';
 import * as _ from 'lodash';
 
 import { ISO6393Languages } from '../constants';
-import { actionIcons, directionIcons } from '@shared/icons';
+import { actionIcons, directionIcons, formIcons } from '@shared/icons';
+import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
 
 @Component({
     selector: 'ia-field-form',
@@ -53,9 +54,11 @@ export class FieldFormComponent {
 
     actionIcons = actionIcons;
     directionIcons = directionIcons;
+    formIcons = formIcons;
 
     constructor(
         private el: ElementRef<HTMLElement>,
+        private corpusDefService: CorpusDefinitionService,
     ) {}
 
     get fields(): FormArray {
@@ -147,5 +150,9 @@ export class FieldFormComponent {
         const selector = '#' + this.moveControlID(index, field, delta);
         const button = this.el.nativeElement.querySelector<HTMLButtonElement>(selector);
         button.focus();
+    }
+
+    nextStep() {
+        this.corpusDefService.activateStep(3);
     }
 }

--- a/frontend/src/app/corpus-definitions/form/form-feedback/form-feedback.component.html
+++ b/frontend/src/app/corpus-definitions/form/form-feedback/form-feedback.component.html
@@ -1,0 +1,13 @@
+    <div class="block" role="status">
+        <div class="message is-success" *ngIf="showSuccess">
+            <p class="message-body">
+                Changes saved!
+            </p>
+        </div>
+        <div class="message is-danger" *ngIf="showError">
+            <p class="message-body">
+                Something went wrong saving your changes. Please try again.
+                If you keep seeing this error, please contact support.
+            </p>
+        </div>
+    </div>

--- a/frontend/src/app/corpus-definitions/form/form-feedback/form-feedback.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/form-feedback/form-feedback.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormFeedbackComponent } from './form-feedback.component';
+
+describe('FormFeedbackComponent', () => {
+  let component: FormFeedbackComponent;
+  let fixture: ComponentFixture<FormFeedbackComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FormFeedbackComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(FormFeedbackComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/corpus-definitions/form/form-feedback/form-feedback.component.ts
+++ b/frontend/src/app/corpus-definitions/form/form-feedback/form-feedback.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ia-form-feedback',
+  templateUrl: './form-feedback.component.html',
+  styleUrl: './form-feedback.component.scss'
+})
+export class FormFeedbackComponent {
+    @Input() showSuccess: boolean;
+    @Input() showError: boolean;
+}

--- a/frontend/src/app/corpus-definitions/form/image-upload/image-upload.component.html
+++ b/frontend/src/app/corpus-definitions/form/image-upload/image-upload.component.html
@@ -37,3 +37,6 @@
         </button>
     </div>
 </div>
+
+
+<ia-form-feedback [showSuccess]="showSuccess" [showError]="showError" />

--- a/frontend/src/app/corpus-definitions/form/image-upload/image-upload.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/image-upload/image-upload.component.spec.ts
@@ -1,12 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ImageUploadComponent } from './image-upload.component';
-import { SharedModule } from 'primeng/api';
 import { ApiService } from '@services';
 import { ApiServiceMock } from 'mock-data/api';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
 import { CorpusDefinition } from '@models/corpus-definition';
 import { SlugifyPipe } from '@shared/pipes/slugify.pipe';
+import { FormFeedbackComponent } from '../form-feedback/form-feedback.component';
+import { SharedModule } from '@shared/shared.module';
 
 describe('ImageUploadComponent', () => {
     let component: ImageUploadComponent;
@@ -14,7 +15,10 @@ describe('ImageUploadComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [ImageUploadComponent],
+            declarations: [
+                ImageUploadComponent,
+                FormFeedbackComponent,
+            ],
             imports: [SharedModule],
             providers: [
                 CorpusDefinitionService,

--- a/frontend/src/app/corpus-definitions/form/image-upload/image-upload.component.ts
+++ b/frontend/src/app/corpus-definitions/form/image-upload/image-upload.component.ts
@@ -22,6 +22,9 @@ export class ImageUploadComponent {
     imageUpdated$ = new Subject<void>();
     imageURL$: Observable<string>;
 
+    showSuccess = false;
+    showError = false;
+
     constructor(
         private corpusDefService: CorpusDefinitionService,
         private apiService: ApiService,
@@ -45,6 +48,9 @@ export class ImageUploadComponent {
 
 
     onImageUpload(event: InputEvent) {
+        this.showSuccess = false;
+        this.showError = false;
+
         const files: File[] = event.target['files'];
         const file = files ? _.first(files) : undefined;
         this.file$.next(file);
@@ -60,6 +66,9 @@ export class ImageUploadComponent {
     }
 
     deleteImage() {
+        this.showSuccess = false;
+        this.showError = false;
+
         const corpusName = this.corpusDefService.corpus$.value.definition.name;
         this.apiService.deleteCorpusImage(corpusName).pipe(
             takeUntil(this.destroy$),
@@ -69,7 +78,15 @@ export class ImageUploadComponent {
     }
 
     onImageUpdate() {
-        this.corpus.save();
+        this.corpus.save().subscribe(() => {
+            this.showSuccess = true;
+            this.showError = false;
+        });
+    }
+
+    onRequestError() {
+        this.showSuccess = false;
+        this.showError = true;
     }
 
 }

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -70,19 +70,8 @@
         </p>
     </div>
 
-    <div class="block" role="status">
-        <div class="message is-success" *ngIf="showSuccessMessage$ | async">
-            <p class="message-body">
-                Changes saved!
-            </p>
-        </div>
-        <div class="message is-danger" *ngIf="showErrorMessage$ | async">
-            <p class="message-body">
-                Something went wrong saving your changes. Please try again.
-                If you keep seeing this error, please contact support.
-            </p>
-        </div>
-    </div>
+    <ia-form-feedback [showSuccess]="showSuccessMessage$ | async"
+        [showError]="showErrorMessage$ | async" />
 </form>
 
 <div class="box">

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -62,11 +62,26 @@
 
     <div class="field">
         <p class="control">
-            <button class="button is-primary">
+            <button class="button is-primary"
+                [class.is-loading]="loading$ | async">
                 <span class="icon"><fa-icon [icon]="formIcons.confirm" /></span>
                 <span>Save changes</span>
             </button>
         </p>
+    </div>
+
+    <div class="block" role="status">
+        <div class="message is-success" *ngIf="showSuccessMessage$ | async">
+            <p class="message-body">
+                Changes saved!
+            </p>
+        </div>
+        <div class="message is-danger" *ngIf="showErrorMessage$ | async">
+            <p class="message-body">
+                Something went wrong saving your changes. Please try again.
+                If you keep seeing this error, please contact support.
+            </p>
+        </div>
     </div>
 </form>
 

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -89,6 +89,10 @@
     <ia-image-upload [corpus]="corpus" />
 </div>
 
+<div class="box">
+    <ia-documentation-form />
+</div>
+
 <div class="block">
     <button class="button" (click)="nextStep()"
         [class.is-disabled]="nextStepDisabled$ | async">

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -93,10 +93,10 @@
     <ia-documentation-form />
 </div>
 
-<div class="block">
-    <button class="button" (click)="nextStep()"
-        [class.is-disabled]="nextStepDisabled$ | async">
+<div class="block" *ngIf="nextStep$ | async as step">
+    <button class="button" (click)="goToNextStep()"
+        [class.is-disabled]="step.disabled">
         <span class="icon"><fa-icon [icon]="actionIcons.next" /></span>
-        <span>Add sample data</span>
+        <span>{{step.label}}</span>
     </button>
 </div>

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -92,11 +92,3 @@
 <div class="box">
     <ia-documentation-form />
 </div>
-
-<div class="block" *ngIf="nextStep$ | async as step">
-    <button class="button" (click)="goToNextStep()"
-        [class.is-disabled]="step.disabled">
-        <span class="icon"><fa-icon [icon]="actionIcons.next" /></span>
-        <span>{{step.label}}</span>
-    </button>
-</div>

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.html
@@ -62,7 +62,10 @@
 
     <div class="field">
         <p class="control">
-            <button class="button is-primary">Save changes</button>
+            <button class="button is-primary">
+                <span class="icon"><fa-icon [icon]="formIcons.confirm" /></span>
+                <span>Save changes</span>
+            </button>
         </p>
     </div>
 </form>
@@ -72,7 +75,9 @@
 </div>
 
 <div class="block">
-    <button class="button" (click)="nextStep()">
-        Next
+    <button class="button" (click)="nextStep()"
+        [class.is-disabled]="nextStepDisabled$ | async">
+        <span class="icon"><fa-icon [icon]="actionIcons.next" /></span>
+        <span>Add sample data</span>
     </button>
 </div>

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.spec.ts
@@ -11,6 +11,7 @@ import { ImageUploadComponent } from '../image-upload/image-upload.component';
 import { ApiService } from '@services';
 import { ApiServiceMock } from 'mock-data/api';
 import { CorpusDefinition } from '@models/corpus-definition';
+import { FormFeedbackComponent } from '../form-feedback/form-feedback.component';
 
 
 describe('MetaFormComponent', () => {
@@ -19,7 +20,11 @@ describe('MetaFormComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [MetaFormComponent, ImageUploadComponent],
+            declarations: [
+                MetaFormComponent,
+                ImageUploadComponent,
+                FormFeedbackComponent
+            ],
             imports: [
                 SharedModule,
                 ReactiveFormsModule,

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.spec.ts
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.spec.ts
@@ -12,6 +12,7 @@ import { ApiService } from '@services';
 import { ApiServiceMock } from 'mock-data/api';
 import { CorpusDefinition } from '@models/corpus-definition';
 import { FormFeedbackComponent } from '../form-feedback/form-feedback.component';
+import { DocumentationFormComponent } from '../documentation-form/documentation-form.component';
 
 
 describe('MetaFormComponent', () => {
@@ -23,7 +24,8 @@ describe('MetaFormComponent', () => {
             declarations: [
                 MetaFormComponent,
                 ImageUploadComponent,
-                FormFeedbackComponent
+                DocumentationFormComponent,
+                FormFeedbackComponent,
             ],
             imports: [
                 SharedModule,

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.ts
@@ -5,11 +5,11 @@ import {
     OnDestroy, SimpleChanges
 } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { Subject, take, takeUntil } from 'rxjs';
+import { Subject, take, takeUntil, map, Observable } from 'rxjs';
 import { CorpusDefinitionService } from '../../corpus-definition.service';
 import { CorpusDefinition } from '../../../models/corpus-definition';
 import { ISO6393Languages } from '../constants';
-import { actionIcons } from '@shared/icons';
+import { actionIcons, formIcons } from '@shared/icons';
 
 @Component({
     selector: 'ia-meta-form',
@@ -47,7 +47,11 @@ export class MetaFormComponent implements OnChanges, OnDestroy {
 
     languageOptions = ISO6393Languages;
     actionIcons = actionIcons;
+    formIcons = formIcons;
 
+    nextStepDisabled$: Observable<boolean> = this.corpusDefService.steps$.pipe(
+        map(steps => steps[1].disabled)
+    );
 
     constructor(
         private formBuilder: FormBuilder,
@@ -84,7 +88,6 @@ export class MetaFormComponent implements OnChanges, OnDestroy {
             newMeta as CorpusDefinition['definition']['meta'];
         this.corpus.save().subscribe({
             next: (value) => {
-                this.corpusDefService.toggleStepDisabled(1);
                 this.metaForm.patchValue(value.definition.meta);
             },
             error: console.error,

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.ts
@@ -37,8 +37,8 @@ export class MetaFormComponent implements OnChanges, OnDestroy {
         description: [''],
         category: [''],
         date_range: this.formBuilder.group({
-            min: [''],
-            max: [''],
+            min: [],
+            max: [],
         }),
         languages: [['']],
     });

--- a/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/meta-form/meta-form.component.ts
@@ -11,6 +11,7 @@ import { APIEditableCorpus, CorpusDefinition } from '../../../models/corpus-defi
 import { ISO6393Languages } from '../constants';
 import { actionIcons, formIcons } from '@shared/icons';
 import { mergeAsBooleans } from '@utils/observables';
+import { MenuItem } from 'primeng/api';
 
 @Component({
     selector: 'ia-meta-form',
@@ -50,8 +51,8 @@ export class MetaFormComponent implements OnChanges, OnDestroy {
     actionIcons = actionIcons;
     formIcons = formIcons;
 
-    nextStepDisabled$: Observable<boolean> = this.corpusDefService.steps$.pipe(
-        map(steps => steps[1].disabled)
+    nextStep$: Observable<MenuItem> = this.corpusDefService.steps$.pipe(
+        map(steps => steps[1]),
     );
 
     changesSubmitted$ = new Subject<void>();
@@ -112,7 +113,7 @@ export class MetaFormComponent implements OnChanges, OnDestroy {
         });
     }
 
-    nextStep() {
+    goToNextStep() {
         this.corpusDefService.activateStep(1);
     }
 

--- a/frontend/src/app/models/corpus-definition.ts
+++ b/frontend/src/app/models/corpus-definition.ts
@@ -52,8 +52,8 @@ export interface APICorpusDefinition {
         description?: string;
         languages?: string[];
         date_range?: {
-            min: string;
-            max: string;
+            min: number;
+            max: number;
         };
     };
     source_data: {

--- a/frontend/src/app/settings/change-password/change-password.component.spec.ts
+++ b/frontend/src/app/settings/change-password/change-password.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
 
 import { ChangePasswordComponent } from './change-password.component';
-import { SharedModule } from 'primeng/api';
+import { SharedModule } from '@shared/shared.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AuthService } from '@services';
 import { AuthServiceMock } from 'mock-data/auth';

--- a/frontend/src/app/settings/change-username/change-username.component.spec.ts
+++ b/frontend/src/app/settings/change-username/change-username.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChangeUsernameComponent } from './change-username.component';
-import { SharedModule } from 'primeng/api';
+import { SharedModule } from '@shared/shared.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AuthService } from '@services';
 import { AuthServiceMock } from 'mock-data/auth';

--- a/frontend/src/app/utils/observables.ts
+++ b/frontend/src/app/utils/observables.ts
@@ -1,0 +1,17 @@
+import * as _ from 'lodash';
+import { map, merge, Observable } from 'rxjs'
+
+/**
+ * Merge observables into a boolean observable, where each source observable maps to
+ * either a stream of "false" events, or a stream of "true" events.
+ *
+ * For example, you can create a `loading$` observable for an HTTP request, by
+ * mapping each time the request is sent to `true`, and each received response to `false`.
+ */
+export const mergeAsBooleans = (
+    observables: { true: Observable<any>[], false: Observable<any>[], }
+): Observable<boolean> => {
+    const trues = observables.true.map(obs => obs.pipe(map(_.constant(true))));
+    const falses = observables.false.map(obs => obs.pipe(map(_.constant(false))));
+    return merge(...trues, ...falses);
+}

--- a/frontend/src/mock-data/corpus-definition.ts
+++ b/frontend/src/mock-data/corpus-definition.ts
@@ -7,8 +7,8 @@ export const mockCorpusDefinition: APICorpusDefinition = {
         description: 'JSON corpus definition for testing',
         category: 'book',
         date_range: {
-            min: '1800-01-01',
-            max: '1900-01-01'
+            min: 1800,
+            max: 1900,
         },
         languages: ['en'],
     },


### PR DESCRIPTION
Builds on #1792. Some improvements to the workflow in the corpus form:

- Moved the documentation form to step 1 (corpus information), instead of making it a separate step.
- Added success / error messages and loading spinners to save buttons in steps 1 (corpus info) and 3 (fields). Left step 2 as-is because that one still needs more work (#1795)
- Changed the logic for disabling steps; this is now done by checking the content after every save. The exact requirements will probably still need some tweaking.
- Added a button on the bottom of the page to move to the next step.