### PR TITLE
Hotfix/5.18.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,5 +35,5 @@ keywords:
   - elasticsearch
   - natural language processing
 license: MIT
-version: 5.18.0
-date-released: '2025-04-10'
+version: 5.18.1
+date-released: '2025-05-20'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,4 +36,4 @@ keywords:
   - natural language processing
 license: MIT
 version: 5.18.1
-date-released: '2025-05-20'
+date-released: '2025-05-22'

--- a/backend/download/apps.py
+++ b/backend/download/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DownloadConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'download'
+
+    def ready(self):
+        import download.signals

--- a/backend/download/signals.py
+++ b/backend/download/signals.py
@@ -1,9 +1,13 @@
 import logging
+import os
+
 from django.conf import settings
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from download.convert_csv import output_path
+
 from .models import Download
-import os
+
 logger = logging.getLogger()
 
 
@@ -13,5 +17,11 @@ def after_download_delete(sender, instance, **kwargs):
         try:
             full_path = os.path.join(settings.CSV_FILES_PATH, instance.filename)
             os.remove(full_path)
+
+            converted_path = output_path(
+                settings.CSV_FILES_PATH, instance.filename)[0]
+            if os.path.exists(converted_path):
+                os.remove(converted_path)
+
         except Exception as e:
             logger.error(f"Error deleting file {instance.filename}: {e}")

--- a/backend/download/signals.py
+++ b/backend/download/signals.py
@@ -1,0 +1,17 @@
+import logging
+from django.conf import settings
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from .models import Download
+import os
+logger = logging.getLogger()
+
+
+@receiver(post_delete, sender=Download)
+def after_download_delete(sender, instance, **kwargs):
+    if instance.filename:
+        try:
+            full_path = os.path.join(settings.CSV_FILES_PATH, instance.filename)
+            os.remove(full_path)
+        except Exception as e:
+            logger.error(f"Error deleting file {instance.filename}: {e}")

--- a/backend/download/tests/test_download_views.py
+++ b/backend/download/tests/test_download_views.py
@@ -243,9 +243,9 @@ def test_unauthenticated_download(db, client, basic_mock_corpus, basic_corpus_pu
                            content_type='application/json'
                            )
     assert status.is_success(response.status_code)
+    # check that download object is removed
     download_objects = Download.objects.all()
-    assert download_objects.count() == 1
-    assert download_objects.first().user == None
+    assert download_objects.count() == 0
 
 def test_query_text_in_csv(db, client, basic_mock_corpus, basic_corpus_public, index_basic_mock_corpus):
     es_query = query.set_query_text(mock_match_all_query(), 'ghost')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i-analyzer",
-  "version": "5.18.0",
+  "version": "5.18.1",
   "license": "MIT",
   "scripts": {
     "postinstall": "yarn install-back && yarn install-front",


### PR DESCRIPTION
Downloads directory is growing out of bounds with incoming requests.

This hotfix implements a signal that removes downloaded files from when the model is deleted.

Proposed query to clean up the csv directory:
`to_delete = Download.objects.exclude(completed__isnull=True).filter(user__isnull=True)`
This removes all completed anonymous downloads.