### PR TITLE
Improved corpus descriptions

### DIFF
--- a/backend/corpora/dbnl/dbnl.py
+++ b/backend/corpora/dbnl/dbnl.py
@@ -14,7 +14,7 @@ from corpora.dbnl.dbnl_metadata import DBNLMetadata
 
 class DBNL(XMLCorpusDefinition):
     title = 'DBNL'
-    description = 'Digital Library for Dutch Literature'
+    description = 'Dutch literature and publications on literary or linguistic studies, from the Middle Ages to the 19th century'
     data_directory = settings.DBNL_DATA
     min_date = datetime(year=1200, month=1, day=1)
     max_date = datetime(year=1890, month=12, day=31)

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
@@ -12,8 +12,8 @@ class DutchNewsPapersAll(DutchNewspapersPublic):
     to use this corpus without including the public counterpart in your environment.
     '''
 
-    title = "Dutch Newspapers (Delpher)"
-    description = "Collection of all Dutch newspapers by the KB"
+    title = "Dutch Newspapers (all)"
+    description = "Collection of all Dutch newspapers digitised by the Koninklijke Bibliotheek."
     data_directory = settings.DUTCHNEWSPAPERS_ALL_DATA
     es_index = getattr(settings, 'DUTCHNEWSPAPERS_ALL_ES_INDEX', 'dutchnewspapers-all')
     max_date = datetime(year=1995, month=12, day=31)

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -29,8 +29,8 @@ class DutchNewspapersPublic(XMLCorpusDefinition):
     variation in the key: it MUST be `'dutchnewspapers-public'`
     '''
 
-    title = "Public Dutch Newspapers"
-    description = "Publicly available collection of Dutch newspapers by the KB"
+    title = "Dutch Newspapers (public)"
+    description = "Collection of Dutch newspapers in the public domain, digitised by the Koninklijke Bibliotheek."
     min_date = datetime(year=1600, month=1, day=1)
     max_date = datetime(year=1876, month=12, day=31)
     data_directory = settings.DUTCHNEWSPAPERS_DATA

--- a/backend/corpora/ecco/description/ecco.md
+++ b/backend/corpora/ecco/description/ecco.md
@@ -1,8 +1,12 @@
-*Eighteenth Century Collections Online (ECCO)* is a fully text-searchable corpus of books, pamphlets and broadsides in all subjects printed between 1701 and 1800. It currently contains over 135,000 titles amounting to over 26 million fully searchable pages. *ECCO* is a digitization of the eighteenth-century section of the works catalogued in the *English Short-title Catalogue (ESTC)*.
+*Eighteenth Century Collections Online (ECCO)* is a corpus of books, pamphlets and broadsides in all subjects printed between 1701 and 1800. It currently contains over 135,000 titles amounting to over 26 million pages.
 
-Most of these works were printed in England, Scotland, Ireland and the United States, but it also contains works printed in territories under British colonial rule as well as from countries across Europe and Asia.
+*ECCO* is a digitization of the eighteenth-century section of the works catalogued in the *English Short-title Catalogue (ESTC)*. The ESTC project has been recording all works published or printed in Britain, Ireland, territories under British colonial rule, and the United States. It also catalogues material printed elsewhere which contains significant text in English, Welsh, Irish or Gaelic, as well as any book falsely claiming to have been printed in Britain or its territories.
 
-The corpus includes everything from six-penny broadsheets, pamphlets, books, government documents and more, written by or about people of all professions and classes.
+Most of these works were printed in England, Scotland, Ireland and the United States, but it also contains works printed in territories under British colonial rule as well as from countries across Europe and Asia. In terms of languages, the vast majority of works are in English, with several thousand in French or Latin, smaller numbers in Ancient Greek, German, Italian, Scots Gaelic, Spanish and Welsh, and a few in other languages.
+
+In this library you will find all eighteenth-century knowledge and discover eighteenth-century lives, as well as what they did, thought, said, hoped for, believed, and the events they lived through. There are government documents and writings by people of all professions and classes with the lower classes often found in legal documents or six-penny broadsheets such as [Elizabeth Canning](/search/ecco?author=Canning%252C%2520Elizabeth), a maidservant, who became one of the most famous English criminal mysteries of the eighteenth century.
+
+The works themselves vary from multi-volume encyclopaedia—so you can find out what was thought of as "knowledge" in the eighteenth century—to dictionaries, law books, histories, poetry, novels, and plays, biographies, works of science, philosophy, theology, religious books, tracts and sermons, royal, government or local proclamations, letters, journals and diaries, almanacks, acts of parliament, works on art, architecture, and auction catalogues, music, petitions, schoolbooks, to name a few.
 
 ### Subjects
 
@@ -27,9 +31,9 @@ The corpus includes everything from six-penny broadsheets, pamphlets, books, gov
 
 Additional information can be found in the links below.
 
-- [Access through publisher website (requires Utrecht University login)](https://go-gale-com.proxy.library.uu.nl/ps/start.do?p=ECCO&u=utrecht)
-- [About this archive (publisher website; requires Utrecht University login)](https://go-gale-com.proxy.library.uu.nl/ps/helpCenter?userGroupName=utrecht&inPS=true&nspage=true&prodId=ECCO&docId=EFZIPA587871271)
-- [Sample topics and searches (publisher website; requires Utrecht University login)](https://go-gale-com.proxy.library.uu.nl/ps/helpCenter?userGroupName=utrecht&inPS=true&nspage=true&prodId=ECCO&docId=OAWADC058207024&title=Sample%20Topics%20and%20Searches)
+- [Search ECCO on the publisher website (requires Utrecht University login)](https://databases.library.uu.nl/ECCO)
+- [About this archive (publisher website)](https://www.gale.com/intl/primary-sources/eighteenth-century-collections-online)
+- [Wikipedia entry](https://en.wikipedia.org/wiki/Eighteenth_Century_Collections_Online)
 
 ### Availability
 

--- a/backend/corpora/ecco/ecco.py
+++ b/backend/corpora/ecco/ecco.py
@@ -25,7 +25,7 @@ from media.media_url import media_url
 
 class Ecco(XMLCorpusDefinition):
     title = "Eighteenth Century Collections Online"
-    description = "Digital collection of books published in Great Britain during the 18th century."
+    description = "Printed works published in Great Britain and its territories during the 18th century."
     description_page = 'ecco.md'
     min_date = datetime(year=1700, month=1, day=1)
     max_date = datetime(year=1800, month=12, day=31)

--- a/backend/corpora/gallica/description/figaro.md
+++ b/backend/corpora/gallica/description/figaro.md
@@ -1,0 +1,12 @@
+This corpus contains digitised issues from *Le Figaro*, a French national newspaper.
+
+Starting out as a satirical journal in 1826, *Le Figaro* was revived with weekly publications in 1854 (the start of this collection), and become a daily paper in 1866. Publications temporarily ceased during World War II, to avoid submitting to censorship. While *Le Figaro* remains a major French newspaper to this day, this collection contains publications until 1954.
+
+The data for this corpus is retrieved from [Gallica](https://gallica.bnf.fr/), the digital library of the [Bibliothèque nationale de France](https://www.bnf.fr/). Gallica offers free access to a large collection of data, spanning different time periods and media.
+
+
+## Read more
+
+- [Browse this collection on Gallica](https://gallica.bnf.fr/ark:/12148/cb34355551z/date)
+- [*Le Figaro* on Wikipedia](https://en.wikipedia.org/wiki/Le_Figaro)
+- [*Le Figaro* on Encyclopaedia Britannica](https://www.britannica.com/topic/Le-Figaro)

--- a/backend/corpora/gallica/figaro.py
+++ b/backend/corpora/gallica/figaro.py
@@ -7,7 +7,7 @@ from corpora.gallica.gallica import Gallica
 
 class Figaro(Gallica):
     title = "Le Figaro"
-    description = "Archive of the French daily newspaper Le Figaro."
+    description = "Archive of Le Figaro, a French daily newspaper."
     min_date = datetime(year=1854, month=1, day=1)
     max_date = datetime(year=1954, month=12, day=31)
     corpus_id = "cb34355551z"

--- a/backend/corpora/gallica/figaro.py
+++ b/backend/corpora/gallica/figaro.py
@@ -7,13 +7,14 @@ from corpora.gallica.gallica import Gallica
 
 class Figaro(Gallica):
     title = "Le Figaro"
-    description = "Newspaper archive, 1854-1954"
+    description = "Archive of the French daily newspaper Le Figaro."
     min_date = datetime(year=1854, month=1, day=1)
     max_date = datetime(year=1954, month=12, day=31)
     corpus_id = "cb34355551z"
     category = "periodical"
     es_index = getattr(settings, 'FIGARO_INDEX', 'figaro')
     image = "figaro.jpg"
+    description_page = 'figaro.md'
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -32,7 +32,7 @@ PROCESSED = "corpora/guardianobserver/processed.txt"
 
 class GuardianObserver(XMLCorpusDefinition):
     title = "Guardian-Observer"
-    description = "Newspaper archive, 1791-2003"
+    description = "Archives from The Guardian, a British daily newspaper, and its sister Sunday paper, the Observer."
     description_page = 'guardianobserver.md'
     min_date = datetime(year=1791, month=1, day=1)
     max_date = datetime(year=2003, month=12, day=31)

--- a/backend/corpora/parliament/netherlands.py
+++ b/backend/corpora/parliament/netherlands.py
@@ -441,7 +441,7 @@ class ParliamentNetherlands(Parliament, XMLCorpusDefinition):
     """
 
     title = "People & Parliament (Netherlands)"
-    description = "Speeches from the Eerste Kamer and Tweede Kamer"
+    description = "Debates in the Dutch national parliament, from its founding to the present. A collection of the speeches in the Eerste Kamer and Tweede Kamer."
     min_date = datetime(year=1815, month=1, day=1)
     max_date = datetime(year=2022, month=12, day=31)
 

--- a/backend/corpora/times/times.py
+++ b/backend/corpora/times/times.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 class Times(XMLCorpusDefinition):
     title = "Times"
-    description = "Newspaper archive, 1785-2010"
+    description = "Archives from The Times, a British daily newspaper."
     min_date = datetime(year=1785, month=1, day=1)
     max_date = datetime(year=2010, month=12, day=31)
     data_directory = settings.TIMES_DATA


### PR DESCRIPTION
- Updates a lot of the short descriptions for corpora to offer more explanation and remove redundant information. These are also better for SEO and whatnot.
- Updates the description page for ECCO to replace some dead links and add some of the description from Gale's site.
- Corrected the ECCO description which suggested the collection included only works from Great Britain.
- Adds a description page for Le Figaro.