### PR TITLE
Add `word_model_path` for Dutchnewspapers corpora

### DIFF
--- a/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
@@ -17,6 +17,7 @@ class DutchNewsPapersAll(DutchNewspapersPublic):
     data_directory = settings.DUTCHNEWSPAPERS_ALL_DATA
     es_index = getattr(settings, 'DUTCHNEWSPAPERS_ALL_ES_INDEX', 'dutchnewspapers-all')
     max_date = datetime(year=1995, month=12, day=31)
+    word_model_path = getattr(settings, "DUTCHNEWSPAPERS_WM", None)
 
     def update_body(self, doc=None):
         if not doc:

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -40,6 +40,7 @@ class DutchNewspapersPublic(XMLCorpusDefinition):
     category = 'periodical'
     description_page = 'description_public.md'
     citation_page = 'citation_public.md'
+    word_model_path = getattr(settings, "DUTCHNEWSPAPERS_WM", None)
 
     @property
     def es_settings(self):


### PR DESCRIPTION
This branch prepares adding the models of 19th century data (older is not feasible due to mixed language).