### PR TITLE
Feature/index status check

### DIFF
--- a/backend/addcorpus/models.py
+++ b/backend/addcorpus/models.py
@@ -539,8 +539,11 @@ class CorpusDocumentationPage(models.Model):
 
 
 class CorpusDataFile(models.Model):
+    def upload_dir(self):
+        return os.path.join('corpus_datafiles', f'{self.corpus.pk}')
+
     def upload_path(self, filename):
-        return os.path.join('corpus_datafiles', f'{self.corpus.pk}', filename)
+        return os.path.join(self.upload_dir(), filename)
 
     corpus = models.ForeignKey(to=Corpus, on_delete=models.CASCADE)
     file = models.FileField(upload_to=upload_path,

--- a/backend/ianalyzer/urls.py
+++ b/backend/ianalyzer/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from addcorpus import urls as corpus_urls
 from addcorpus.views import (CorpusDataFileViewSet, CorpusDefinitionViewset,
                              CorpusDocumentationPageViewset)
+from indexing.views import IndexHealthView
 from api import urls as api_urls
 from api.views import QueryViewset
 from django.conf import settings
@@ -30,6 +31,7 @@ from tag import urls as tag_urls
 from tag.views import TagViewSet
 from visualization import urls as visualization_urls
 from wordmodels import urls as wordmodels_urls
+from indexing import urls as indexing_urls
 
 from .index import index
 from .proxy_frontend import proxy_frontend
@@ -61,6 +63,7 @@ urlpatterns = [
     path('api/wordmodels/', include(wordmodels_urls)),
     path('api/es/', include(es_urls)),
     path('api/tag/', include(tag_urls)),
+    path('api/indexing/', include(indexing_urls)),
     path('api-auth/', include(
         'rest_framework.urls',
         namespace='rest_framework',

--- a/backend/indexing/health_check.py
+++ b/backend/indexing/health_check.py
@@ -1,0 +1,143 @@
+from typing import Optional
+
+from addcorpus.models import Corpus, CorpusDataFile
+from es.client import server_for_corpus
+
+from es.models import Server, Index
+from es.sync import fetch_index_metadata
+from es.es_alias import get_current_index_name
+from indexing.models import TaskStatus, IndexJob
+from indexing.run_create_task import make_es_mapping, make_es_settings
+
+
+
+class CorpusIndexHealth:
+    '''
+    Reports on the "health status" of a corpus index.
+
+
+    '''
+
+    corpus: Corpus
+    server: Server
+    index: Optional[Index]
+    latest_job: Optional[IndexJob]
+    latest_data: Optional[CorpusDataFile]
+
+
+    def __init__(self, corpus: Corpus):
+        self.corpus = corpus
+        self.server = self._server()
+        self.index = self._index(self.server)
+        self.latest_job = self._latest_job()
+        self.latest_file = self.latest_datafile()
+
+
+    def _server(self) -> Server:
+        return Server.objects.get(name=server_for_corpus(self.corpus.name))
+
+
+    def _index(self, server: Server) -> Optional[Index]:
+        client = server.client()
+        try:
+            index_name = get_current_index_name(self.corpus.configuration, client)
+        except ValueError: # the corpus has no index
+            index_name = self.corpus.configuration.es_index
+        except: # connection issues etc.
+            return
+
+        index, _ = Index.objects.get_or_create(name=index_name, server=server)
+
+        fetch_index_metadata()
+        index.refresh_from_db()
+
+        return index
+
+
+    def _latest_job(self) -> Optional[IndexJob]:
+        '''
+        Find the latest job for this index. Returns the most recently created job.
+
+        Note that this is not necessarily the latest job that was completed. Mostly
+        informative when the corpus is indexed through the form, which does not enable
+        complex job management (such as running older jobs).
+        '''
+        jobs = IndexJob.objects.filter(corpus=self.corpus)
+        if jobs.exists():
+            return jobs.latest('created')
+
+
+    def _latest_datafile(self) -> CorpusDataFile:
+        '''
+        Find the most recent data file for this corpus. Will not return a value for
+        Python corpora.
+        '''
+        files = CorpusDataFile.objects.filter(corpus_configuration__corpus=self.corpus)
+        if files.exists():
+            return files.latest('created')
+
+
+    @property
+    def server_active(self) -> bool:
+        '''
+        Whether the server can be reached.
+        '''
+        return self.server.can_connect()
+
+
+    @property
+    def index_active(self) -> Optional[bool]:
+        '''
+        Whether there is an active index for the corpus.
+
+        Returns `None` if the `index` property is empty. This happens when the server
+        cannot be reached.
+        '''
+        if self.index:
+            return self.index.available
+
+
+    @property
+    def settings_compatible(self) -> Optional[bool]:
+        '''
+        Whether the index settings in Elasticsearch are compatible with the corpus
+        configuration
+        '''
+
+        if self.index:
+            generated_settings = make_es_settings(self.corpus)
+            actual_settings = self.index.settings()
+
+            if 'analysis' in generated_settings:
+                return actual_settings.get('analysis', None) == generated_settings['analysis']
+
+
+    @property
+    def mappings_compatible(self) -> Optional[bool]:
+        '''
+        Whether the field mappings in Elasticsearch match the corpus configuration
+        '''
+        if self.index:
+            generated_mappings = make_es_mapping(self.corpus.configuration)
+            actual_mappings = self.index.mappings
+            return generated_mappings == actual_mappings
+
+
+    @property
+    def job_status(self) -> Optional[TaskStatus]:
+        '''
+        Status of the last IndexJob
+        '''
+        if self.latest_job:
+            return self.latest_job.status()
+
+    @property
+    def includes_latest_data(self) -> Optional[bool]:
+        '''
+        Whether the last index job included the most recent data for the corpus.
+
+        Checks whether the job was created *after* the data was uploaded. This is
+        reliable in the context of the corpus form.
+        '''
+        if self.latest_job and self.latest_data:
+            return self.latest_job.created > self.latest_data.created

--- a/backend/indexing/health_check.py
+++ b/backend/indexing/health_check.py
@@ -10,14 +10,15 @@ from es.es_alias import get_current_index_name
 from indexing.models import TaskStatus, IndexJob
 from indexing.run_create_task import make_es_mapping, make_es_settings
 from addcorpus.json_corpora.import_json import get_path
-
+from addcorpus.validation.indexing import CorpusNotIndexableError
 
 
 class CorpusIndexHealth:
     '''
     Reports on the "health status" of a corpus index.
 
-
+    This class groups various diagnostic functions. This can be used to report on the
+    index status to the user or for internal troubleshooting.
     '''
 
     corpus: Corpus
@@ -146,3 +147,22 @@ class CorpusIndexHealth:
         '''
         if self.latest_job and self.latest_file:
             return self.latest_job.created > self.latest_file.created
+
+    @property
+    def corpus_ready_to_index(self) -> bool:
+        '''
+        Whether the corpus configuration passes validation for indexing
+        '''
+        return self.corpus.ready_to_index()
+
+    @property
+    def corpus_validation_feedback(self) -> Optional[str]:
+        '''
+        If the corpus does not pass validation for indexing, returns the validation error
+        message.
+        '''
+        try:
+            self.corpus.validate_ready_to_index()
+        except CorpusNotIndexableError as e:
+            return str(e)
+

--- a/backend/indexing/health_check.py
+++ b/backend/indexing/health_check.py
@@ -123,6 +123,10 @@ class CorpusIndexHealth:
             actual_mappings = self.index.mappings()
             return generated_mappings == actual_mappings
 
+    @property
+    def index_compatible(self) -> Optional[bool]:
+        return self.settings_compatible and self.mappings_compatible
+
 
     @property
     def job_status(self) -> Optional[TaskStatus]:

--- a/backend/indexing/run_create_task.py
+++ b/backend/indexing/run_create_task.py
@@ -16,7 +16,7 @@ from indexing.models import (
 logger = logging.getLogger('indexing')
 
 
-def _make_es_settings(corpus: Corpus) -> Dict:
+def make_es_settings(corpus: Corpus) -> Dict:
     if corpus.has_python_definition:
         corpus_def = load_corpus_definition(corpus.name)
         return corpus_def.es_settings
@@ -27,7 +27,7 @@ def _make_es_settings(corpus: Corpus) -> Dict:
     )
 
 
-def _make_es_mapping(corpus_configuration: CorpusConfiguration) -> Dict:
+def make_es_mapping(corpus_configuration: CorpusConfiguration) -> Dict:
     '''
     Create the ElasticSearch mapping for the fields of this corpus. May be
     passed to the body of an ElasticSearch index creation request.
@@ -46,7 +46,7 @@ def create(task: CreateIndexTask):
 
     corpus_config = task.corpus.configuration
     index_name = task.index.name
-    es_mapping = _make_es_mapping(corpus_config)
+    es_mapping = make_es_mapping(corpus_config)
 
     if client.indices.exists(index=index_name, allow_no_indices=False):
         if task.delete_existing:
@@ -59,7 +59,7 @@ def create(task: CreateIndexTask):
             )
             raise Exception('index already exists')
 
-    settings = _make_es_settings(task.corpus)
+    settings = make_es_settings(task.corpus)
 
     if task.production_settings:
         logger.info('Adding prod settings to index')

--- a/backend/indexing/serializers.py
+++ b/backend/indexing/serializers.py
@@ -1,4 +1,6 @@
-from rest_framework.serializers import Serializer, BooleanField, ChoiceField, IntegerField
+from rest_framework.serializers import (
+    Serializer, BooleanField, ChoiceField, IntegerField, CharField
+)
 
 from indexing.models import TaskStatus
 
@@ -9,3 +11,5 @@ class IndexHealthSerializer(Serializer):
     index_compatible = BooleanField()
     job_status = ChoiceField(choices=TaskStatus.choices)
     includes_latest_data = BooleanField()
+    corpus_ready_to_index = BooleanField()
+    corpus_validation_feedback = CharField()

--- a/backend/indexing/serializers.py
+++ b/backend/indexing/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework.serializers import Serializer, BooleanField, ChoiceField, IntegerField
+
+from indexing.models import TaskStatus
+
+class IndexHealthSerializer(Serializer):
+    corpus = IntegerField(source='corpus.pk')
+    server_active = BooleanField()
+    index_active = BooleanField()
+    index_compatible = BooleanField()
+    job_status = ChoiceField(choices=TaskStatus.choices)
+    includes_latest_data = BooleanField()

--- a/backend/indexing/tests/test_health_check.py
+++ b/backend/indexing/tests/test_health_check.py
@@ -11,6 +11,7 @@ def test_health_check_not_indexed(mock_corpus, es_index_client, es_server):
     assert health.mappings_compatible is None
     assert health.job_status is None
     assert health.includes_latest_data is None
+    assert health.corpus_ready_to_index
 
 def test_health_check_index_python_corpus(small_mock_corpus, index_small_mock_corpus):
     corpus = Corpus.objects.get(name=small_mock_corpus)
@@ -21,6 +22,7 @@ def test_health_check_index_python_corpus(small_mock_corpus, index_small_mock_co
     assert health.mappings_compatible
     assert health.job_status == TaskStatus.DONE
     assert health.includes_latest_data is None # this is a python corpus, so NA
+    assert health.corpus_ready_to_index
 
 def test_health_check_indexed_db_corpus(json_mock_corpus, index_json_mock_corpus):
     health = CorpusIndexHealth(json_mock_corpus)
@@ -30,3 +32,4 @@ def test_health_check_indexed_db_corpus(json_mock_corpus, index_json_mock_corpus
     assert health.mappings_compatible
     assert health.job_status == TaskStatus.DONE
     assert health.includes_latest_data is True
+    assert health.corpus_ready_to_index

--- a/backend/indexing/tests/test_health_check.py
+++ b/backend/indexing/tests/test_health_check.py
@@ -1,0 +1,32 @@
+from addcorpus.models import Corpus
+from indexing.models import TaskStatus
+from indexing.health_check import CorpusIndexHealth
+
+def test_health_check_not_indexed(mock_corpus, es_index_client, es_server):
+    corpus = Corpus.objects.get(name=mock_corpus)
+    health = CorpusIndexHealth(corpus)
+    assert health.server_active
+    assert health.index_active is False
+    assert health.settings_compatible is None
+    assert health.mappings_compatible is None
+    assert health.job_status is None
+    assert health.includes_latest_data is None
+
+def test_health_check_index_python_corpus(small_mock_corpus, index_small_mock_corpus):
+    corpus = Corpus.objects.get(name=small_mock_corpus)
+    health = CorpusIndexHealth(corpus)
+    assert health.server_active
+    assert health.index_active
+    assert health.settings_compatible
+    assert health.mappings_compatible
+    assert health.job_status == TaskStatus.DONE
+    assert health.includes_latest_data is None # this is a python corpus, so NA
+
+def test_health_check_indexed_db_corpus(json_mock_corpus, index_json_mock_corpus):
+    health = CorpusIndexHealth(json_mock_corpus)
+    assert health.server_active
+    assert health.index_active
+    assert health.settings_compatible
+    assert health.mappings_compatible
+    assert health.job_status == TaskStatus.DONE
+    assert health.includes_latest_data is True

--- a/backend/indexing/tests/test_indexing_views.py
+++ b/backend/indexing/tests/test_indexing_views.py
@@ -1,0 +1,13 @@
+from rest_framework import status
+
+def test_health_view(admin_user, admin_client, json_mock_corpus, index_json_mock_corpus):
+    json_mock_corpus.owner = admin_user
+    json_mock_corpus.save()
+
+    response = admin_client.get(
+        f'/api/indexing/health/{json_mock_corpus.id}',
+        content_type='application/json'
+    )
+
+    assert status.is_success(response.status_code)
+    assert response.data['index_active'] == True

--- a/backend/indexing/tests/test_indexing_views.py
+++ b/backend/indexing/tests/test_indexing_views.py
@@ -1,6 +1,6 @@
 from rest_framework import status
 
-def test_health_view(admin_user, admin_client, json_mock_corpus, index_json_mock_corpus):
+def test_health_view(admin_user, admin_client, json_mock_corpus, index_json_mock_corpus, es_server):
     json_mock_corpus.owner = admin_user
     json_mock_corpus.save()
 

--- a/backend/indexing/tests/test_serializers.py
+++ b/backend/indexing/tests/test_serializers.py
@@ -1,0 +1,7 @@
+from indexing.serializers import IndexHealthSerializer
+from indexing.health_check import CorpusIndexHealth
+
+def test_index_health_serializer(json_mock_corpus, index_json_mock_corpus):
+    health = CorpusIndexHealth(json_mock_corpus)
+    serializer = IndexHealthSerializer(health)
+    assert serializer.data

--- a/backend/indexing/tests/test_serializers.py
+++ b/backend/indexing/tests/test_serializers.py
@@ -1,7 +1,7 @@
 from indexing.serializers import IndexHealthSerializer
 from indexing.health_check import CorpusIndexHealth
 
-def test_index_health_serializer(json_mock_corpus, index_json_mock_corpus):
+def test_index_health_serializer(json_mock_corpus, index_json_mock_corpus, es_server):
     health = CorpusIndexHealth(json_mock_corpus)
     serializer = IndexHealthSerializer(health)
     assert serializer.data

--- a/backend/indexing/urls.py
+++ b/backend/indexing/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from indexing.views import IndexHealthView
+
+urlpatterns = [
+    path('health/<str:corpus>', IndexHealthView.as_view()),
+]

--- a/backend/indexing/views.py
+++ b/backend/indexing/views.py
@@ -1,0 +1,15 @@
+from rest_framework.generics import get_object_or_404
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from addcorpus.permissions import editable_corpora
+from indexing.serializers import IndexHealthSerializer
+from indexing.health_check import CorpusIndexHealth
+
+class IndexHealthView(APIView):
+    def get(self, request, corpus: str):
+        queryset = editable_corpora(request.user)
+        corpus_obj = get_object_or_404(queryset, id=corpus)
+        health = CorpusIndexHealth(corpus_obj)
+        serializer = IndexHealthSerializer(health)
+        return Response(serializer.data)


### PR DESCRIPTION
Close #1791 

Adds a `CorpusIndexHealth` class that groups some diagnostics for the index status of a corpus. (Is there an index, does it include the latest data, is the corpus valid for indexing, etc.) Also includes a view to inspect this in the API (if you are allowed to edit the corpus).

This is primarily intended to build an indexing interface in the corpus form, but may be interesting to add to the CLI in the future.