### PR TITLE
add fallback test workflow

### DIFF
--- a/.github/workflows/fallback-test.yml
+++ b/.github/workflows/fallback-test.yml
@@ -1,0 +1,23 @@
+name: Fallback test workflow
+
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+
+jobs:
+  backend-test-fallback:
+    name: Test Backend
+    runs-on: ubuntu-latest
+    steps:
+    - name: Do nothing
+      run: |
+        echo "No test run"
+  frontend-test-fallback:
+    name: Test Frontend
+    runs-on: ubuntu-latest
+    steps:
+    - name: Do nothing
+      run: |
+        echo "No test run"

--- a/backend/addcorpus/tests/test_citation.py
+++ b/backend/addcorpus/tests/test_citation.py
@@ -27,5 +27,4 @@ def test_citation_page(citation_template):
         assert result == expected
 
 
-def test_contradiction():
-    assert False is True
+

--- a/backend/addcorpus/tests/test_citation.py
+++ b/backend/addcorpus/tests/test_citation.py
@@ -25,3 +25,7 @@ def test_citation_page(citation_template):
 
         result = render_documentation_context(citation_template)
         assert result == expected
+
+
+def test_contradiction():
+    assert False is True

--- a/backend/addcorpus/tests/test_citation.py
+++ b/backend/addcorpus/tests/test_citation.py
@@ -25,7 +25,3 @@ def test_citation_page(citation_template):
 
         result = render_documentation_context(citation_template)
         assert result == expected
-
-
-def test_contradiction():
-    assert False is True


### PR DESCRIPTION
This is a potential fix for the issue that the "Test Backend" and "Test Frontend" checks are required for merging, but skipped if there are no changes in their respective directories. So if you make a PR with, say, no changes to the frontend, you have to bypass branch protection rules to merge.

Solution from: https://github.com/orgs/community/discussions/26251#discussioncomment-3250964

This adds a "fallback" test workflow that is always run and always succeeds. Because the fallback jobs are also called "Test Backend" and "Test Frontend", they will satisfy the branch protection rules. But if the real test workflow is also triggered, github will require both to succeed.