### PR TITLE
improve field auto import

### DIFF
--- a/backend/addcorpus/json_corpora/csv_field_info.py
+++ b/backend/addcorpus/json_corpora/csv_field_info.py
@@ -1,0 +1,48 @@
+import datetime
+import os
+from typing import Dict, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+
+def get_csv_info(path: Union[str, os.PathLike], **kwargs) -> Dict:
+    df = pd.read_csv(path, **kwargs)
+    info = {
+        col_name: map_col(df[col_name]) for col_name in df.columns
+    }
+    return info
+
+
+def map_col(col: pd.Series) -> str:
+    if col.dtypes == object:
+        if is_date_col(col):
+            return 'date'
+        return 'text'
+    elif col.dtypes == np.float64:
+        return 'float'
+    elif col.dtypes == np.int64:
+        return 'integer'
+    elif col.dtypes == bool:
+        return 'boolean'
+    return 'text'
+
+
+def is_date_col(col: pd.Series) -> bool:
+    '''Check if a column only contains dates or missing values
+    Converts empty strings to None because they are non picked up by `isna()`
+    '''
+    non_null = col.replace('', None)
+    non_null = non_null[~non_null.isna()]
+    if non_null.empty:
+        return False
+    mask = non_null.transform(is_date)
+    return mask.all()
+
+
+def is_date(input: str) -> Optional[datetime.datetime]:
+    try:
+        datetime.datetime.strptime(input, '%Y-%m-%d')
+        return True
+    except (ValueError, TypeError):
+        return False

--- a/backend/addcorpus/json_corpora/csv_field_info.py
+++ b/backend/addcorpus/json_corpora/csv_field_info.py
@@ -1,6 +1,6 @@
 import datetime
 import os
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Any
 
 import numpy as np
 import pandas as pd
@@ -18,14 +18,16 @@ def map_col(col: pd.Series) -> str:
     if col.dtypes == object:
         if is_date_col(col):
             return 'date'
-        return 'text'
+        if is_long_text_col(col):
+            return 'text_content'
+        return 'text_metadata'
     elif col.dtypes == np.float64:
         return 'float'
     elif col.dtypes == np.int64:
         return 'integer'
     elif col.dtypes == bool:
         return 'boolean'
-    return 'text'
+    return 'text_metadata'
 
 
 def is_date_col(col: pd.Series) -> bool:
@@ -46,3 +48,11 @@ def is_date(input: str) -> Optional[datetime.datetime]:
         return True
     except (ValueError, TypeError):
         return False
+
+
+def is_long_text(value: Any) -> bool:
+    return isinstance(value, str) and (len(value) > 100 or '\n' in value)
+
+
+def is_long_text_col(col: pd.Series) -> bool:
+    return col.apply(is_long_text).any()

--- a/backend/addcorpus/json_corpora/tests/test_csv_field_info.py
+++ b/backend/addcorpus/json_corpora/tests/test_csv_field_info.py
@@ -1,5 +1,9 @@
-from addcorpus.json_corpora.csv_field_info import is_date, is_date_col
+import os
+from addcorpus.json_corpora.csv_field_info import (
+    is_date, is_date_col, is_long_text, get_csv_info
+)
 import pandas as pd
+from addcorpus.python_corpora.load_corpus import load_corpus_definition
 
 
 def test_is_date():
@@ -17,3 +21,24 @@ def test_is_date_col():
     assert is_date_col(clean_date_series)
     assert is_date_col(dirty_date_series)
     assert not is_date_col(empty_series)
+
+
+def test_is_long_text():
+    assert not is_long_text('Example')
+    assert is_long_text('To be or not to be,\nThat is the question')
+    assert is_long_text(
+        'It is a truth universally acknowledged, that a single man in possession of a good fortune must be in want of a wife.',
+    )
+    assert not is_long_text(None)
+
+
+def test_map_col(small_mock_corpus):
+    dir = load_corpus_definition(small_mock_corpus).data_directory
+    filepath = os.path.join(dir, 'example.csv')
+    info = get_csv_info(filepath)
+    assert info == {
+        'date': 'date',
+        'genre': 'text_metadata',
+        'title': 'text_metadata',
+        'content': 'text_content',
+    }

--- a/backend/addcorpus/json_corpora/tests/test_csv_field_info.py
+++ b/backend/addcorpus/json_corpora/tests/test_csv_field_info.py
@@ -1,4 +1,4 @@
-from addcorpus.utils import is_date, is_date_col
+from addcorpus.json_corpora.csv_field_info import is_date, is_date_col
 import pandas as pd
 
 

--- a/backend/addcorpus/tests/test_datafiles.py
+++ b/backend/addcorpus/tests/test_datafiles.py
@@ -22,8 +22,8 @@ def test_csv_upload(admin_user, admin_client, json_mock_corpus):
     info_res = admin_client.get(f'/api/corpus/datafiles/{file_pk}/info/')
     assert info_res.status_code == HTTP_200_OK
     assert info_res.data == {
-        'character': 'text',
-        'line': 'text',
+        'character': 'text_metadata',
+        'line': 'text_metadata',
         'date-column': 'date',
         'FLOAT COLUMN': 'float',
         'int_column': 'integer',

--- a/backend/addcorpus/utils.py
+++ b/backend/addcorpus/utils.py
@@ -1,53 +1,8 @@
 import datetime
 import os
-from typing import Dict, Optional, Union
-
-import numpy as np
-import pandas as pd
+from typing import Union
 
 from addcorpus.models import Corpus
-
-
-def get_csv_info(path: Union[str, os.PathLike], **kwargs) -> Dict:
-    df = pd.read_csv(path, **kwargs)
-    info = {
-        col_name: map_col(df[col_name]) for col_name in df.columns
-    }
-    return info
-
-
-def map_col(col: pd.Series) -> str:
-    if col.dtypes == object:
-        if is_date_col(col):
-            return 'date'
-        return 'text'
-    elif col.dtypes == np.float64:
-        return 'float'
-    elif col.dtypes == np.int64:
-        return 'integer'
-    elif col.dtypes == bool:
-        return 'boolean'
-    return 'text'
-
-
-def is_date_col(col: pd.Series) -> bool:
-    '''Check if a column only contains dates or missing values
-    Converts empty strings to None because they are non picked up by `isna()`
-    '''
-    non_null = col.replace('', None)
-    non_null = non_null[~non_null.isna()]
-    if non_null.empty:
-        return False
-    mask = non_null.transform(is_date)
-    return mask.all()
-
-
-def is_date(input: str) -> Optional[datetime.datetime]:
-    try:
-        datetime.datetime.strptime(input, '%Y-%m-%d')
-        return True
-    except (ValueError, TypeError):
-        return False
 
 
 def normalize_date_to_year(input: Union[datetime.date, datetime.datetime, int]) -> int:

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -12,7 +12,8 @@ from addcorpus.serializers import (CorpusDataFileSerializer,
                                    CorpusDocumentationPageSerializer,
                                    CorpusJSONDefinitionSerializer,
                                    CorpusSerializer)
-from addcorpus.utils import get_csv_info, clear_corpus_image
+from addcorpus.utils import clear_corpus_image
+from addcorpus.json_corpora.csv_field_info import get_csv_info
 from django.conf import settings
 from django.http.response import FileResponse
 from rest_framework import viewsets

--- a/frontend/src/app/corpus-definitions/corpus-definition.service.ts
+++ b/frontend/src/app/corpus-definitions/corpus-definition.service.ts
@@ -81,14 +81,14 @@ export class CorpusDefinitionService implements OnDestroy {
     }
 
     public makeDefaultField(
-        dtype: APICorpusDefinitionField['type'] | 'text',
+        dtype: APICorpusDefinitionField['type'],
         colName: string
     ): APICorpusDefinitionField {
         let field: Partial<APICorpusDefinitionField> = {
             name: this.slugify.transform(colName),
             display_name: colName,
             description: '',
-            type: dtype == 'text' ? 'text_metadata' : dtype,
+            type: dtype,
             extract: {
                 column: colName,
             },
@@ -116,15 +116,25 @@ export class CorpusDefinitionService implements OnDestroy {
                     hidden: false,
                 };
             }
-            case 'text': {
+            case 'text_metadata': {
                 field.options = {
                     search: true,
                     filter: 'show',
                     preview: false,
-                    visualize: false,
+                    visualize: true,
                     sort: false,
                     hidden: false,
                 };
+            }
+            case 'text_content': {
+                field.options = {
+                    search: true,
+                    filter: 'none',
+                    preview: true,
+                    visualize: true,
+                    sort: false,
+                    hidden: false,
+                }
             }
         }
         return field as APICorpusDefinitionField;

--- a/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
+++ b/frontend/src/app/corpus-definitions/form/field-form/field-form.component.ts
@@ -3,6 +3,7 @@ import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import {
     APICorpusDefinitionField,
     CorpusDefinition,
+    FIELD_TYPE_OPTIONS,
 } from '@models/corpus-definition';
 import { MenuItem } from 'primeng/api';
 import { Observable, Subject, takeUntil } from 'rxjs';
@@ -26,40 +27,7 @@ export class FieldFormComponent {
         fields: new FormArray([]),
     });
 
-    fieldTypeOptions: MenuItem[] = [
-        {
-            label: 'text (content)',
-            value: 'text_content',
-            helpText:
-                'Main document text. Can consist of multiple paragraphs. Can be used to search.',
-            hasLanguage: true,
-        },
-        {
-            label: 'text (metadata)',
-            value: 'text_metadata',
-            helpText:
-                'Metadata text. Limited to a single paragraph. Can be used to filter and/or search.',
-            hasLanguage: true,
-        },
-        {
-            label: 'number (integer)', value: 'integer',
-            helpText: 'This field contains whole numbers',
-        },
-        {
-            label: 'number (decimal)', value: 'float',
-            helpText: 'This field contains numbers with (optional) decimals',
-        },
-        {
-            label: 'date',
-            value: 'date',
-            helpText: 'This field contains dates.',
-        },
-        {
-            label: 'boolean',
-            value: 'boolean',
-            helpText: 'This field contains true/false values.',
-        },
-    ];
+    fieldTypeOptions: MenuItem[] = FIELD_TYPE_OPTIONS;
 
     languageOptions = ISO6393Languages;
 

--- a/frontend/src/app/corpus-definitions/form/upload-sample/upload-sample.component.html
+++ b/frontend/src/app/corpus-definitions/form/upload-sample/upload-sample.component.html
@@ -17,7 +17,7 @@
         <tbody>
             <tr *ngFor="let field of fileInfo|keyvalue">
                 <td>{{field.key}}</td>
-                <td>{{field.value}}</td>
+                <td>{{fieldTypeLabel(field.value)}}</td>
             </tr>
         </tbody>
     </table>

--- a/frontend/src/app/corpus-definitions/form/upload-sample/upload-sample.component.ts
+++ b/frontend/src/app/corpus-definitions/form/upload-sample/upload-sample.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Corpus } from '@models';
-import { CorpusDataFile, DataFileInfo } from '@models/corpus-definition';
+import { APICorpusDefinitionField, CorpusDataFile, DataFileInfo, FIELD_TYPE_OPTIONS } from '@models/corpus-definition';
 import { ApiService, DialogService } from '@services';
 import { actionIcons, formIcons } from '@shared/icons';
 import { CorpusDefinitionService } from 'app/corpus-definitions/corpus-definition.service';
@@ -127,4 +127,9 @@ export class UploadSampleComponent implements OnInit, OnDestroy {
     openDocumentation() {
         this.dialogService.showManualPage('uploading-source-data');
     }
+
+    fieldTypeLabel(value: APICorpusDefinitionField['type']) {
+        return FIELD_TYPE_OPTIONS.find(option => option.value == value)?.label;
+    }
+
 }

--- a/frontend/src/app/models/corpus-definition.ts
+++ b/frontend/src/app/models/corpus-definition.ts
@@ -153,4 +153,44 @@ export class CorpusDefinition {
         this.loading$.next(false);
         this.hasImage = result.has_image;
     }
-}
+};
+
+export const FIELD_TYPE_OPTIONS: {
+    label: string,
+    value: APICorpusDefinitionField['type'],
+    helpText: string,
+    hasLanguage?: boolean,
+}[] = [
+    {
+        label: 'text (content)',
+        value: 'text_content',
+        helpText:
+            'Main document text. Can consist of multiple paragraphs. Can be used to search.',
+        hasLanguage: true,
+    },
+    {
+        label: 'text (metadata)',
+        value: 'text_metadata',
+        helpText:
+            'Metadata text. Limited to a single paragraph. Can be used to filter and/or search.',
+        hasLanguage: true,
+    },
+    {
+        label: 'number (integer)', value: 'integer',
+        helpText: 'This field contains whole numbers',
+    },
+    {
+        label: 'number (decimal)', value: 'float',
+        helpText: 'This field contains numbers with (optional) decimals',
+    },
+    {
+        label: 'date',
+        value: 'date',
+        helpText: 'This field contains dates.',
+    },
+    {
+        label: 'boolean',
+        value: 'boolean',
+        helpText: 'This field contains true/false values.',
+    },
+];


### PR DESCRIPTION
Small improvement to the field import from CSV files. This now distinguishes between `text_content` and `text_metadata` fields. (Distinction is based on length + line breaks.)

Corpora must have at least one content field to pass validation, so this means a typical corpus is actually valid after the CSV upload.

Also, the labels for datatypes in the `SampleUploadComponent` now match the ones in the field form.