### PR TITLE
Bugfix/iso languages import

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,6 @@
     "vega": "^5.32.0",
     "vega-embed": "^6.26.0",
     "vega-lite": "^5.19.0",
-    "vite": "^6.2.7",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
@@ -89,7 +88,8 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.2",
     "karma-jasmine": "^4.0.0",
-    "karma-jasmine-html-reporter": "^1.5.0"
+    "karma-jasmine-html-reporter": "^1.5.0",
+    "vite": "^6.2.7"
   },
   "peerDependencies": {
     "webpack": "^5.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,6 @@
     "ngx-cookie-service": "19.1.0",
     "ngx-matomo-client": "7.0.1",
     "primeng": "^19.0.5",
-    "process": "^0.11.10",
     "rxjs": "^7.8.1",
     "smoothscroll-polyfill": "^0.3.6",
     "typescript": "5.7.3",

--- a/frontend/src/app/corpus-definitions/form/constants.ts
+++ b/frontend/src/app/corpus-definitions/form/constants.ts
@@ -1,4 +1,4 @@
 import * as iso6393 from '@freearhey/iso-639-3';
 import { values } from 'lodash';
 
-export const ISO6393Languages = values(iso6393);
+export const ISO6393Languages = values(iso6393)[0];

--- a/frontend/src/app/footer/footer.component.ts
+++ b/frontend/src/app/footer/footer.component.ts
@@ -9,7 +9,7 @@ import { environment } from '@environments/environment';
     standalone: false
 })
 export class FooterComponent {
-    environment = environment;
+    environment = environment as any;
 
     constructor() { }
 

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -62,7 +62,3 @@ import 'zone.js';  // Included with Angular CLI.
  * Need to import at least one locale-data with intl.
  */
 // import 'intl/locale-data/jsonp/en';
-
-/** Needed for elasticsearch */
-import * as process from 'process';
-window['process'] = process;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6708,11 +6708,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
-
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"


### PR DESCRIPTION
The import of the ISO 639-3 language package was not getting the correct object; not sure what changed there, but it works now.

Because Vite gives some warning about not being able to optimise this package, I initially spent some time digging through dependencies, so this also includes some minor changes:
- Moved Vite to the `devDependencies`
- Removed process because it looks like that isn't needed anymore

Also fixed a build error if the environment omits optional properties.