### PR TITLE
Change CORPORA setting format

### DIFF
--- a/backend/addcorpus/python_corpora/load_corpus.py
+++ b/backend/addcorpus/python_corpora/load_corpus.py
@@ -1,60 +1,40 @@
 import logging
-import re
 import sys
-from importlib import util
-from os.path import abspath, dirname
+from os.path import dirname
+from django.utils.module_loading import import_string
+from typing import Type, Optional, Dict
+from inspect import getabsfile
 
 from addcorpus.python_corpora.corpus import CorpusDefinition
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
-from addcorpus.python_corpora.corpus import CorpusDefinition
 
 
-def corpus_path(corpus_name):
-    return abspath(settings.CORPORA.get(corpus_name))
-
-def corpus_dir(corpus_name):
+def corpus_dir(corpus_name: str) -> str:
     """Gets the absolute path to the corpus definition directory
 
     Arguments:
         corpus_name {str} -- Key of the corpus in CORPORA object in settings
     """
-    return dirname(corpus_path(corpus_name))
+    corpus = load_corpus_definition(corpus_name)
+    return dirname(getabsfile(corpus.__class__))
 
-def load_corpus_definition(corpus_name) -> CorpusDefinition:
-    filepath = corpus_path(corpus_name)
-    try:
-        corpus_spec = util.spec_from_file_location(
-            corpus_name,
-            filepath)
 
-        corpus_mod = util.module_from_spec(corpus_spec)
-    except FileNotFoundError:
-        logger.critical(
-            'No module describing the corpus "{0}" found in the specified file path:\
-            {1}'.format(corpus_name, filepath)
-        )
-        raise
+def load_corpus_definition(corpus_name) -> Type[CorpusDefinition]:
+    import_path = settings.CORPORA.get(corpus_name)
+    return import_string(import_path)()
 
-    corpus_spec.loader.exec_module(corpus_mod)
-    # assume the class name is the same as the corpus name,
-    # allowing for differences in camel case vs. lower case
-    regex = re.compile('[^a-zA-Z]')
-    corpus_name = regex.sub('', corpus_name).lower()
-    endpoint = next((attr for attr in dir(corpus_mod)
-                     if attr.lower() == corpus_name), None)
-    corpus_class = getattr(corpus_mod, endpoint)
-    return corpus_class()
 
-def _try_loading_corpus_definition(corpus_name, stderr=sys.stderr):
+def _try_loading_corpus_definition(corpus_name, stderr=sys.stderr) -> Optional[CorpusDefinition]:
     try:
         return load_corpus_definition(corpus_name)
     except Exception as e:
         message = 'Could not load corpus {}: {}'.format(corpus_name, e)
         print(message, file=stderr)
 
-def load_all_corpus_definitions(stderr=sys.stderr):
+
+def load_all_corpus_definitions(stderr=sys.stderr) -> Dict[str, CorpusDefinition]:
     '''
     Return a dict with corpus names and corpus definition objects.
     '''

--- a/backend/addcorpus/python_corpora/tests/test_corpusimport.py
+++ b/backend/addcorpus/python_corpora/tests/test_corpusimport.py
@@ -16,12 +16,12 @@ def test_key_error(db, settings):
 
 def test_import_error(db, settings):
     ''' Verify that exceptions is correctly raised
-    - in case the file path in config.CORPORA is faulty
+    - in case the path in config.CORPORA is faulty
     '''
 
-    settings.CORPORA = {'times2': '/somewhere/times/times.py'}
+    settings.CORPORA = {'times2': 'somewhere.times.times.Times'}
 
-    with pytest.raises(FileNotFoundError) as e:
+    with pytest.raises(ModuleNotFoundError) as e:
         load_corpus.load_corpus_definition('times2')
 
     # corpus should not be included when
@@ -30,40 +30,9 @@ def test_import_error(db, settings):
     assert 'times2' not in corpora
     assert not Corpus.objects.filter(name='times2')
 
-mock_corpus_definition = '''
-class Times():
-    title = "Times"
-    description = "Newspaper archive, 1785-2010"
-    fields = []
-    es_index = 'some-other-name'
-'''
 
-@pytest.fixture()
-def temp_times_definition(tmpdir, settings):
-    '''Provide a temporary definition files for the
-    times corpus
-    '''
-    testdir = tmpdir.mkdir('/testdir')
-
-    with open(os.path.join(testdir, 'times.py'), 'w') as f:
-        f.write(mock_corpus_definition)
-    path_testfile = str(testdir)+'/times.py'
-
-    settings.CORPORA = {'times': path_testfile}
-
-def test_import_from_anywhere(db, temp_times_definition):
-    ''' Verify that the corpus definition
-    can live anywhere in the file system
-    '''
-    corpus_definitions = load_corpus.load_all_corpus_definitions()
-    assert 'times' in corpus_definitions
-    corpus = corpus_definitions['times']
-    assert corpus.title == 'Times'
-
-def test_corpus_dir_is_absolute(db, temp_times_definition):
-    corpus_dir = load_corpus.corpus_dir('times')
-    assert os.path.isabs(corpus_dir)
-
-def test_mismatch_corpus_index_names(temp_times_definition):
-    times = load_corpus.load_corpus_definition('times')
-    assert times.es_index == 'some-other-name'
+def test_corpus_dir(db, settings, basic_mock_corpus):
+    path = load_corpus.corpus_dir(basic_mock_corpus)
+    assert os.path.isabs(path)
+    assert 'mock_csv_corpus.py' in os.listdir(path)
+    assert 'source_data' in os.listdir(path)

--- a/backend/addcorpus/python_corpora/tests/test_times_source.py
+++ b/backend/addcorpus/python_corpora/tests/test_times_source.py
@@ -9,7 +9,7 @@ from addcorpus.python_corpora import load_corpus
 @pytest.fixture()
 def times_test_settings(settings):
     settings.CORPORA = {
-        'times': join(settings.BASE_DIR, 'corpora/times/times.py')
+        'times': 'corpora.times.times.Times',
     }
     settings.TIMES_DATA = join(settings.BASE_DIR, 'addcorpus/python_corpora/tests')
     settings.TIMES_ES_INDEX = 'test-times'

--- a/backend/addcorpus/tests/test_field_order.py
+++ b/backend/addcorpus/tests/test_field_order.py
@@ -1,41 +1,23 @@
-import shutil
-import os
+from addcorpus.models import Corpus
+from addcorpus.python_corpora.load_corpus import load_corpus_definition
+from addcorpus.python_corpora.save_corpus import _save_corpus_configuration
 
-from addcorpus.python_corpora.save_corpus import load_and_save_all_corpora
+def test_field_order_python_corpus(small_mock_corpus, admin_client):
+    # check field order matches corpus definition
+    response = admin_client.get('/api/corpus/')
+    corpus_data = next(c for c in response.data if c['name'] == small_mock_corpus)
+    field_names = [field['name'] for field in corpus_data['fields']]
+    assert field_names == ['date', 'title', 'content', 'genre']
 
-def test_field_order_python_corpus(small_mock_corpus, admin_client, tmpdir, settings):
-	# check field order matches corpus definition
-	response = admin_client.get('/api/corpus/')
-	corpus_data = next(c for c in response.data if c['name'] == small_mock_corpus)
-	field_names = [field['name'] for field in corpus_data['fields']]
-	assert field_names == ['date', 'title', 'content', 'genre']
+    # update field order
+    corpus = Corpus.objects.get(name=small_mock_corpus)
+    definition = load_corpus_definition(small_mock_corpus)
+    definition.fields = list(reversed(definition.fields))
+    _save_corpus_configuration(corpus, definition)
 
-	# copy corpus definition into tmpdir
-	current_dir = os.path.join(settings.BASE_DIR, 'corpora_test', 'small')
-	shutil.copytree(current_dir, tmpdir, dirs_exist_ok=True)
+    # check order is updated
+    response = admin_client.get('/api/corpus/')
+    corpus_data = next(c for c in response.data if c['name'] == small_mock_corpus)
 
-	definition_path = os.path.join(tmpdir, 'small_mock_corpus.py')
-
-	with open(definition_path, 'r') as definition_file:
-		definition_str = definition_file.read()
-
-	# replace `fields = [...]` line in file to change field order
-	definition_str = definition_str.replace(
-		'fields = [date, title_field, content, genre]',
-		'fields = [title_field, content, genre, date]'
-	)
-
-	# save edited definition
-	with open(definition_path, 'w') as definition_file:
-		definition_file.write(definition_str)
-
-	# check order has changed
-	settings.CORPORA[small_mock_corpus] = definition_path
-	load_and_save_all_corpora()
-
-    # Okay this test will never work because it actually just looks at the es_index ordering of fields....
-	response = admin_client.get('/api/corpus/')
-	corpus_data = next(c for c in response.data if c['name'] == small_mock_corpus)
-
-	field_names = [field['name'] for field in corpus_data['fields']]
-	assert field_names == ['title', 'content', 'genre', 'date']
+    field_names = [field['name'] for field in corpus_data['fields']]
+    assert field_names == ['genre', 'content', 'title', 'date']

--- a/backend/corpora/dbnl/tests/test_dbnl_extraction.py
+++ b/backend/corpora/dbnl/tests/test_dbnl_extraction.py
@@ -13,8 +13,8 @@ def dbnl_corpus(settings):
     settings.DBNL_DATA = os.path.join(here, 'data')
     # for testing purposes, also add the metadata helper corpus
     settings.CORPORA = {
-        'dbnl': os.path.join(here, '..', 'dbnl.py'),
-        'dbnl_metadata': os.path.join(here, '..', 'dbnl_metadata.py'),
+        'dbnl': 'corpora.dbnl.dbnl.DBNL',
+        'dbnl_metadata': 'corpora.dbnl.dbnl_metadata.DBNLMetadata',
     }
     return 'dbnl'
 

--- a/backend/corpora/dbnl/tests/test_dbnl_validation.py
+++ b/backend/corpora/dbnl/tests/test_dbnl_validation.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 def test_dbnl_validation(settings):
     settings.DBNL_DATA = os.path.join(here, 'data')
     settings.CORPORA = {
-        'dbnl': os.path.join(here, '..', 'dbnl.py'),
+        'dbnl': 'corpora.dbnl.dbnl.DBNL',
     }
 
     load_and_save_all_corpora()

--- a/backend/corpora/dutchannualreports/dutchannualreports.py
+++ b/backend/corpora/dutchannualreports/dutchannualreports.py
@@ -13,7 +13,6 @@ from ianalyzer_readers.extract import XML, Metadata, Combined
 from addcorpus.python_corpora.filters import MultipleChoiceFilter, RangeFilter
 from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition
 from media.image_processing import get_pdf_info, retrieve_pdf, pdf_pages, build_partial_pdf
-from addcorpus.python_corpora.load_corpus import corpus_dir
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
 
@@ -52,7 +51,7 @@ class DutchAnnualReports(XMLCorpusDefinition):
     def es_settings(self):
         return es_settings(self.languages[:1], stopword_analysis=True, stemming_analysis=True)
 
-    with open(op.join(corpus_dir('dutchannualreports'), 'dutchannualreports_mapping.csv')) as f:
+    with open(op.join(os.path.dirname(__file__), 'dutchannualreports_mapping.csv')) as f:
         reader = csv.DictReader(f)
         for line in reader:
             dutchannualreports_map[line['abbr']] = line['name']

--- a/backend/corpora/dutchannualreports/test_dutchannualreports.py
+++ b/backend/corpora/dutchannualreports/test_dutchannualreports.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_dutchannualreports(settings, db, admin_client):
     settings.CORPORA = {
-        'dutchannualreports': os.path.join(here, 'dutchannualreports.py')
+        'dutchannualreports': 'corpora.dutchannualreports.dutchannualreports.DutchAnnualReports',
     }
     settings.DUTCHANNUALREPORTS_DATA = ''
 

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition, consolidate_start_end_years
 from addcorpus.python_corpora import filters
 from ianalyzer_readers.extract import Metadata, XML
-from addcorpus.python_corpora.load_corpus import corpus_dir
 
 from corpora.utils.constants import document_context
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
@@ -110,7 +109,7 @@ class DutchNewspapersPublic(XMLCorpusDefinition):
                         })
                         yield full_path, meta_dict
 
-    titlefile = join(corpus_dir('dutchnewspapers-public'), 'newspaper_titles.txt')
+    titlefile = join(os.path.dirname(__file__), 'newspaper_titles.txt')
     with open(titlefile, encoding='utf-8') as f:
         papers = f.readlines()
     paper_count = len(papers)

--- a/backend/corpora/dutchnewspapers/test_dutchnewspapers.py
+++ b/backend/corpora/dutchnewspapers/test_dutchnewspapers.py
@@ -5,7 +5,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_dutchnewspapers_public(settings, db, admin_client):
     settings.CORPORA = {
-        'dutchnewspapers-public': os.path.join(here, 'dutchnewspapers_public.py')
+        'dutchnewspapers-public':
+            'corpora.dutchnewspapers.dutchnewspapers_public.DutchNewspapersPublic',
     }
     settings.DUTCHNEWSPAPERS_DATA = ''
 
@@ -14,8 +15,10 @@ def test_dutchnewspapers_public(settings, db, admin_client):
 
 def test_dutchnewspapers_all(settings, admin_client):
     settings.CORPORA = {
-        'dutchnewspapers-all': os.path.join(here, 'dutchnewspapers_all.py'),
-        'dutchnewspapers-public': os.path.join(here, 'dutchnewspapers_public.py')
+        'dutchnewspapers-all':
+            'corpora.dutchnewspapers.dutchnewspapers_all.DutchNewsPapersAll',
+        'dutchnewspapers-public':
+            'corpora.dutchnewspapers.dutchnewspapers_public.DutchNewspapersPublic',
     }
     settings.DUTCHNEWSPAPERS_DATA = ''
     settings.DUTCHNEWSPAPERS_ALL_DATA = ''

--- a/backend/corpora/ecco/test_ecco.py
+++ b/backend/corpora/ecco/test_ecco.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_ecco(settings, db, admin_client):
     settings.CORPORA = {
-        'ecco': os.path.join(here, 'ecco.py')
+        'ecco': 'corpora.ecco.ecco.Ecco',
     }
     settings.ECCO_DATA = ''
 

--- a/backend/corpora/gallica/conftest.py
+++ b/backend/corpora/gallica/conftest.py
@@ -10,9 +10,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 @pytest.fixture()
 def gallica_corpus_settings(settings):
     settings.CORPORA = {
-        "caricature": os.path.join(here, "caricature.py"),
-        "figaro": os.path.join(here, "figaro.py"),
-        "journauxresistance": os.path.join(here, "resistance.py"),
+        "caricature": 'corpora.gallica.caricature.Caricature',
+        "figaro": 'corpora.gallica.figaro.Figaro',
+        "journauxresistance": 'corpora.gallica.resistance.JournauxResistance',
     }
 
 

--- a/backend/corpora/goodreads/tests/test_goodreads.py
+++ b/backend/corpora/goodreads/tests/test_goodreads.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_goodreads(settings, db, admin_client):
     settings.CORPORA = {
-        'goodreads': os.path.join(here, '..', 'goodreads.py')
+        'goodreads': 'corpora.goodreads.goodreads.GoodReads'
     }
     settings.GOODREADS_DATA = ''
 

--- a/backend/corpora/guardianobserver/test_guardianobserver.py
+++ b/backend/corpora/guardianobserver/test_guardianobserver.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_guardian_observer(settings, db, admin_client):
     settings.CORPORA = {
-        'guardian-observer': os.path.join(here, 'guardianobserver.py')
+        'guardian-observer': 'corpora.guardianobserver.guardianobserver.GuardianObserver',
     }
     settings.GO_DATA = ''
 

--- a/backend/corpora/jewishinscriptions/test_jewishinscriptions.py
+++ b/backend/corpora/jewishinscriptions/test_jewishinscriptions.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_jewish_inscriptions(settings, db, admin_client):
     settings.CORPORA = {
-        'jewish-inscriptions': os.path.join(here, 'jewishinscriptions.py')
+        'jewish-inscriptions': 'corpora.jewishinscriptions.jewishinscriptions.JewishInscriptions',
     }
     settings.JEWISH_INSCRIPTIONS_DATA = ''
 

--- a/backend/corpora/jewishmigration/test_jewishmigration.py
+++ b/backend/corpora/jewishmigration/test_jewishmigration.py
@@ -124,7 +124,7 @@ EXPECTED_DOCUMENT = {
 @pytest.fixture
 def jm_corpus_settings(settings):
     settings.CORPORA = {
-        'jewishmigration': os.path.join(here, 'jewishmigration.py')
+        'jewishmigration': 'corpora.jewishmigration.jewishmigration.JewishMigration',
     }
     settings.JMIG_DATA_DIR = None
     settings.JMIG_DATA = None

--- a/backend/corpora/parliament/conftest.py
+++ b/backend/corpora/parliament/conftest.py
@@ -11,22 +11,22 @@ here = os.path.abspath(os.path.dirname(__file__))
 @pytest.fixture()
 def parliament_corpora_settings(settings):
     settings.CORPORA = {
-        'parliament-uk': os.path.join(here, 'uk.py'),
-        'parliament-netherlands': os.path.join(here, 'netherlands.py'),
-        'parliament-canada': os.path.join(here, 'canada.py'),
-        'parliament-germany-new': os.path.join(here, 'germany-new.py'),
-        'parliament-germany-old': os.path.join(here, 'germany-old.py'),
-        'parliament-france': os.path.join(here, 'france.py'),
-        'parliament-sweden': os.path.join(here, 'sweden.py'),
-        'parliament-sweden-old': os.path.join(here, 'sweden-old.py'),
-        'parliament-denmark': os.path.join(here, 'denmark.py'),
-        'parliament-denmark-new': os.path.join(here, 'denmark-new.py'),
-        'parliament-finland': os.path.join(here, 'finland.py'),
-        'parliament-finland-old': os.path.join(here, 'finland-old.py'),
-        'parliament-norway': os.path.join(here, 'norway.py'),
-        'parliament-norway-new': os.path.join(here, 'norway-new.py'),
-        'parliament-ireland': os.path.join(here, 'ireland.py'),
-        'parliament-europe': os.path.join(here, 'euparl.py'),
+        'parliament-uk': 'corpora.parliament.uk.ParliamentUK',
+        'parliament-netherlands': 'corpora.parliament.netherlands.ParliamentNetherlands',
+        'parliament-canada': 'corpora.parliament.canada.ParliamentCanada',
+        'parliament-germany-new': 'corpora.parliament.germany-new.ParliamentGermanyNew',
+        'parliament-germany-old': 'corpora.parliament.germany-old.ParliamentGermanyOld',
+        'parliament-france': 'corpora.parliament.france.ParliamentFrance',
+        'parliament-sweden': 'corpora.parliament.sweden.ParliamentSweden',
+        'parliament-sweden-old': 'corpora.parliament.sweden-old.ParliamentSwedenOld',
+        'parliament-denmark': 'corpora.parliament.denmark.ParliamentDenmark',
+        'parliament-denmark-new': 'corpora.parliament.denmark-new.ParliamentDenmarkNew',
+        'parliament-finland': 'corpora.parliament.finland.ParliamentFinland',
+        'parliament-finland-old': 'corpora.parliament.finland-old.ParliamentFinlandOld',
+        'parliament-norway': 'corpora.parliament.norway.ParliamentNorway',
+        'parliament-norway-new': 'corpora.parliament.norway-new.ParliamentNorwayNew',
+        'parliament-ireland': 'corpora.parliament.ireland.ParliamentIreland',
+        'parliament-europe': 'corpora.parliament.euparl.ParliamentEurope',
     }
 
     settings.PP_CANADA_DATA = os.path.join(here, 'tests', 'data', 'canada')

--- a/backend/corpora/peaceportal/conftest.py
+++ b/backend/corpora/peaceportal/conftest.py
@@ -6,11 +6,11 @@ here = os.path.abspath(os.path.dirname(__file__))
 @pytest.fixture()
 def peace_test_settings(settings):
     settings.CORPORA = {
-        'peaceportal': os.path.join(here, 'peaceportal.py'),
-        'peaceportal-epidat': os.path.join(here, 'epidat.py'),
-        'peaceportal-fiji': os.path.join(here, 'FIJI', 'fiji.py'),
-        'peaceportal-iis': os.path.join(here, 'iis.py'),
-        'peaceportal-tol': os.path.join(here, 'tol.py'),
+        'peaceportal': 'corpora.peaceportal.peaceportal.PeacePortal',
+        'peaceportal-epidat': 'corpora.peaceportal.epidat.PeaceportalEpidat',
+        'peaceportal-fiji': 'corpora.peaceportal.FIJI.fiji.PeaceportalFIJI',
+        'peaceportal-iis': 'corpora.peaceportal.iis.PeaceportalIIS',
+        'peaceportal-tol': 'corpora.peaceportal.tol.PeaceportalTOL',
     }
 
     settings.PEACEPORTAL_EPIDAT_DATA= os.path.join(here, 'tests', 'data', 'epidat')

--- a/backend/corpora/periodicals/test_periodicals.py
+++ b/backend/corpora/periodicals/test_periodicals.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_periodicals(settings, db, admin_client):
     settings.CORPORA = {
-        'periodicals': os.path.join(here, 'periodicals.py')
+        'periodicals': 'corpora.periodicals.periodicals.Periodicals',
     }
     settings.PERIODICALS_DATA = ''
 

--- a/backend/corpora/rechtspraak/conftest.py
+++ b/backend/corpora/rechtspraak/conftest.py
@@ -7,7 +7,7 @@ here = op.abspath(op.dirname(__file__))
 @pytest.fixture()
 def rechtspraak_test_settings(settings):
     settings.CORPORA = {
-        'rechtspraak': op.join(here, 'rechtspraak.py')
+        'rechtspraak': 'corpora.rechtspraak.rechtspraak.Rechtspraak'
     }
 
     settings.RECHTSPRAAK_DATA = op.join(here, 'tests', 'data')

--- a/backend/corpora/times/test_times.py
+++ b/backend/corpora/times/test_times.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_times(settings, db, admin_client):
     settings.CORPORA = {
-        'times': os.path.join(here, 'times.py')
+        'times': 'corpora.times.times.Times',
     }
     settings.TIMES_DATA = ''
 

--- a/backend/corpora/troonredes/test_troonredes.py
+++ b/backend/corpora/troonredes/test_troonredes.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def test_troonredes(settings, db, admin_client):
     settings.CORPORA = {
-        'troonredes': os.path.join(here, 'troonredes.py')
+        'troonredes': 'corpora.troonredes.troonredes.Troonredes'
     }
     settings.TROONREDES_DATA = ''
 

--- a/backend/corpora/uu_course_descriptions/tests/test_hum_course_descriptions.py
+++ b/backend/corpora/uu_course_descriptions/tests/test_hum_course_descriptions.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 @pytest.fixture()
 def hum_course_descriptions_settings(settings, db):
     settings.CORPORA = {
-        'hum_course_descriptions': os.path.join(here, '../uu_course_descriptions_gw_2023.py')
+        'hum_course_descriptions': 'corpora.uu_course_descriptions.uu_course_descriptions_gw_2023.HumCourseDescriptions',
     }
     settings.HUM_COURSE_DESCRIPTIONS_DATA = os.path.join(here, 'data')
 

--- a/backend/corpora/uu_course_descriptions/tests/test_uu_course_descriptions.py
+++ b/backend/corpora/uu_course_descriptions/tests/test_uu_course_descriptions.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 @pytest.fixture()
 def uu_course_descriptions_settings(settings, db):
     settings.CORPORA = {
-        'uu_course_descriptions': os.path.join(here, '../uu_course_descriptions.py')
+        'uu_course_descriptions': 'corpora.uu_course_descriptions.uu_course_descriptions.UUCourseDescriptions'
     }
     settings.UU_COURSE_DESCRIPTIONS_DATA = os.path.join(here, 'data')
 

--- a/backend/ianalyzer/settings_test.py
+++ b/backend/ianalyzer/settings_test.py
@@ -4,14 +4,14 @@ def mock_corpus_path(*path):
     return os.path.join(BASE_DIR, 'corpora_test', *path)
 
 CORPORA = {
-    'small-mock-corpus': mock_corpus_path('small', 'small_mock_corpus.py'),
-    'large-mock-corpus': mock_corpus_path('large', 'large_mock_corpus.py'),
-    'multilingual-mock-corpus': mock_corpus_path('mixed_language', 'multilingual_mock_corpus.py'),
-    'times': os.path.join(BASE_DIR, 'corpora', 'times', 'times.py'),
-    'media-mock-corpus': mock_corpus_path('media', 'media_mock_corpus.py'),
-    'mock-csv-corpus': mock_corpus_path('basic', 'mock_csv_corpus.py'),
-    'wordmodels-mock-corpus': mock_corpus_path('wordmodels', 'wm_mock_corpus.py'),
-    'tagging-mock-corpus': mock_corpus_path('tag', 'tag_mock_corpus.py'),
+    'small-mock-corpus': 'corpora_test.small.small_mock_corpus.SmallMockCorpus',
+    'large-mock-corpus': 'corpora_test.large.large_mock_corpus.LargeMockCorpus',
+    'multilingual-mock-corpus': 'corpora_test.mixed_language.multilingual_mock_corpus.MultilingualMockCorpus',
+    'times': 'corpora.times.times.Times',
+    'media-mock-corpus': 'corpora_test.media.media_mock_corpus.MediaMockCorpus',
+    'mock-csv-corpus': 'corpora_test.basic.mock_csv_corpus.MockCSVCorpus',
+    'wordmodels-mock-corpus': 'corpora_test.wordmodels.wm_mock_corpus.WordmodelsMockCorpus',
+    'tagging-mock-corpus': 'corpora_test.tag.tag_mock_corpus.TaggingMockCorpus',
 }
 
 TIMES_DATA = os.path.join(BASE_DIR, 'addcorpus', 'python_corpora', 'tests')

--- a/documentation/Corpus-definitions.md
+++ b/documentation/Corpus-definitions.md
@@ -55,9 +55,9 @@ Database-only corpora do not support some advanced functionality. Notably:
 
 Python-based corpora are written as Python classes. Each definition should be a subclass of `CorpusDefinition`.
 
-The [corpora](/backend/corpora/) directory contains definitions for all corpora we create. (On top of that, [corpora_test](/backend/corpora_test/) defines corpora for for unit tests. Corpora *can* be saved anywhere.) This directory is not a Django app, but just a collection of scripts and metadata.
+The [corpora](/backend/corpora/) directory contains definitions for all corpora we create. On top of that, [corpora_test](/backend/corpora_test/) defines corpora for for unit tests. This directory is not a Django app, but just a collection of scripts and metadata. (The directory has no special status; you can import corpora from elsewhere.)
 
-To be imported into the application, a definition needs to be added in the Django project settings. The `CORPORA` setting defines a mapping of names and python files, which declares what definitions should be loaded.
+To be imported into the application, a definition needs to be added in the Django project settings. The `CORPORA` setting defines a mapping of names and import paths, which declares what definitions should be loaded.
 
 When you start up a server, all configured corpus definitions will be imported into the database. During much of the runtime, the backend will refer to the database model rather than the Python class. However, this class can be loaded for more advanced features where custom functions may be used. The most common situation where this happens is when you index the source data.
 

--- a/documentation/Django-project-settings.md
+++ b/documentation/Django-project-settings.md
@@ -71,15 +71,13 @@ Unit tests for the backend will assume that there is a default server configured
 
 A dictionary that specifies Python corpus definitions that should be imported in your project.
 
-Each key must be the name of a corpus, where the value gives the absolute path to the Python file that contains the definition. For example:
+Each key must be the import path to a corpus class (see [Django module loading](https://docs.djangoproject.com/en/5.2/ref/utils/#module-django.utils.module_loading)). For example:
 
 ```python
 CORPORA = {
-    'times': '/home/me/ianalyzer/backend/corpora/times/times.py',
+    'times': 'corpora.times.times.Times',
 }
 ```
-
-The key of the corpus must match the name of the corpus class. This match is not case-sensitive, and your key may include extra non-alphabetic characters (they will be ignored when matching). For example, `'times'` is a valid key for the `Times` class, and so is `'TIMES_1'`. It will usually match the filename as well, but this is not strictly necessary.
 
 ### `CORPUS_SERVER_NAMES`
 


### PR DESCRIPTION
This changes the format of the `CORPORA` setting to use import paths rather than file paths. Closes #1639

Pros:
- More conventional format for Django
- Simplifies the `load_corpora` module by using Django's `module_loading` utility
- Clearer error messages when import fails 
- The name for a corpus no longer needs to match the class name.

Cons:
 - All development and deployment configurations would need to be updated.

As far as I'm concerned, https://github.com/CentreForDigitalHumanities/I-analyzer/discussions/1638 can also be closed if this is merged. (This still allows you to import corpus definitions from anywhere, but it gets rid of the complex import logic, opaque naming rules, and absolute paths, where were the reasons I opened the discussion.)