### PR TITLE
Bugfix/download query in context

### DIFF
--- a/backend/addcorpus/models.py
+++ b/backend/addcorpus/models.py
@@ -314,18 +314,18 @@ class CorpusConfiguration(models.Model):
         return False
 
 
-FIELD_DISPLAY_TYPES = [
-    ('text_content', 'text content'),
-    (MappingType.TEXT.value, 'text'),
-    (MappingType.KEYWORD.value, 'keyword'),
-    (MappingType.DATE.value, 'date'),
-    (MappingType.DATE_RANGE.value, 'date_range'),
-    (MappingType.INTEGER.value, 'integer'),
-    (MappingType.FLOAT.value, 'float'),
-    (MappingType.BOOLEAN.value, 'boolean'),
-    (MappingType.GEO_POINT.value, 'geo_point'),
-    ('url', 'url'),
-]
+class FieldDisplayTypes(models.TextChoices):
+    TEXT_CONTENT = ('text_content', 'text content')
+    TEXT = (MappingType.TEXT.value, 'text')
+    KEYWORD = (MappingType.KEYWORD.value, 'keyword')
+    DATE = (MappingType.DATE.value, 'date')
+    DATE_RANGE = (MappingType.DATE_RANGE.value, 'date_range')
+    INTEGER = (MappingType.INTEGER.value, 'integer')
+    FLOAT = (MappingType.FLOAT.value, 'float')
+    BOOLEAN = (MappingType.BOOLEAN.value, 'boolean')
+    GEO_POINT = (MappingType.GEO_POINT.value, 'geo_point')
+    URL = ('url', 'url')
+
 
 FIELD_VISUALIZATIONS = [
     (VisualizationType.RESULTS_COUNT.value, 'Number of results'),
@@ -364,7 +364,7 @@ class Field(models.Model):
     )
     display_type = models.CharField(
         max_length=16,
-        choices=FIELD_DISPLAY_TYPES,
+        choices=FieldDisplayTypes.choices,
         help_text='as what type of data this field is rendered in the interface',
     )
     description = models.CharField(

--- a/backend/download/create_csv.py
+++ b/backend/download/create_csv.py
@@ -1,6 +1,7 @@
 import csv
 import os
 from typing import Dict, Iterable, List, Optional, Union
+from django.utils.html import strip_tags
 
 from django.conf import settings
 
@@ -102,19 +103,16 @@ def _results_csv_fieldnames(
 
 
 def _query_in_context_values(highlights: Dict, context_fields: List[str]) -> Dict:
-    return {
-        f: None
-        for f in context_fields
-    }
+    values = {f: None for f in context_fields}
 
-    # hi_fields = highlights.keys()
-    # for hf in hi_fields:
-    #     for index, hi in enumerate(highlights[hf]):
-    #         highlight_field_name = '{}{}{}'.format(
-    #             hf, QUERY_CONTEXT_INFIX, index + 1)
-    #         field_set.update([highlight_field_name])
-    #         soup = BeautifulSoup(hi, 'html.parser')
-    #         entry.update({highlight_field_name: soup.get_text()})
+    for field in context_fields:
+        snippets = highlights.get(field)
+        if snippets:
+            plain_text_snippets = map(strip_tags, snippets)
+            value = '\n\n'.join(plain_text_snippets)
+            values[_query_in_context_column(field)] = value
+
+    return values
 
 
 def generate_rows(

--- a/backend/download/create_csv.py
+++ b/backend/download/create_csv.py
@@ -4,11 +4,12 @@ from typing import Dict, Iterable, List, Optional, Union
 
 from django.conf import settings
 
-from addcorpus.models import Corpus
+from addcorpus.models import Corpus, FieldDisplayTypes
 from tag.models import TaggedDocument, Tag
 from users.models import CustomUser
 from visualization.term_frequency import parse_datestring
 from tag.filter import corpus_tags
+from visualization.query import get_search_fields, get_query_text
 
 
 DOCUMENT_URL_COL = 'document_link'
@@ -35,8 +36,8 @@ def create_filename(download_id):
 
 def search_results_csv(
     results: Iterable[Dict],
-    fields,
-    query,
+    fields: List[str],
+    query: Dict,
     download_id: str,
     corpus: Corpus,
     user: Optional[CustomUser],
@@ -47,11 +48,14 @@ def search_results_csv(
     '''
     # create csv file
     include_link = 'document_link' in extra_columns
+    context_fields = _query_in_context_fields(corpus, query, extra_columns)
     tags = _tags_to_include(user, corpus, extra_columns)
 
     filename = create_filename(download_id)
-    fieldnames = _results_csv_fieldnames(fields, include_link, tags)
-    entries = generate_rows(results, fields, query, corpus, include_link, tags)
+    fieldnames = _results_csv_fieldnames(fields, include_link, tags, context_fields)
+    entries = generate_rows(
+        results, fields, get_query_text(query), corpus, include_link, tags, context_fields
+    )
 
     filepath = write_file(filename, fieldnames, entries,
                           dialect='resultsDialect')
@@ -70,24 +74,57 @@ def _tag_column(tag: Tag) -> str:
     return f'tag: {tag.name}'
 
 
+def _query_in_context_column(field: str) -> str:
+    return f'query in context: {field}'
+
+
+def _query_in_context_fields(corpus: Corpus, query: Dict, extra_columns: List[str]) -> List[str]:
+    if 'context' in extra_columns:
+        corpus_fields = corpus.configuration.fields.all()
+        query_fieldnames = get_search_fields(query) or [f.name for f in corpus_fields]
+        content_fields = corpus_fields.filter(display_type=FieldDisplayTypes.TEXT_CONTENT)
+        return [ f.name for f in content_fields if f.name in query_fieldnames ]
+
+
 def _results_csv_fieldnames(
-        fields: List[str], include_link: bool, tags: Optional[List[Tag]]
+        fields: List[str], include_link: bool,
+        tags: Optional[List[Tag]],
+        context_fields: List[str]
     ) -> List[str]:
     fields = ['query'] + fields
     if include_link:
         fields += [DOCUMENT_URL_COL]
     if tags:
         fields += list(map(_tag_column, tags))
+    if context_fields:
+        fields += [_query_in_context_column(f) for f in context_fields]
     return fields
+
+
+def _query_in_context_values(highlights: Dict, context_fields: List[str]) -> Dict:
+    return {
+        f: None
+        for f in context_fields
+    }
+
+    # hi_fields = highlights.keys()
+    # for hf in hi_fields:
+    #     for index, hi in enumerate(highlights[hf]):
+    #         highlight_field_name = '{}{}{}'.format(
+    #             hf, QUERY_CONTEXT_INFIX, index + 1)
+    #         field_set.update([highlight_field_name])
+    #         soup = BeautifulSoup(hi, 'html.parser')
+    #         entry.update({highlight_field_name: soup.get_text()})
 
 
 def generate_rows(
         results: Iterable[Dict],
-        corpus_fields: List[str],
+        download_fields: List[str],
         query: str,
         corpus: Corpus,
         include_link: bool,
-        tags: Optional[List[Tag]],
+        tags: Optional[List[Tag]] = None,
+        context_fields: Optional[List[str]] = None,
 ):
     ''' Yields rows of data to be written to the CSV file'''
 
@@ -95,24 +132,18 @@ def generate_rows(
         entry = {'query': query}
         doc_id = result['_id']
 
-        for field in corpus_fields:
+        for field in download_fields:
             # this assures that old indices, which have their id on
             # the top level '_id' field, will fill in id here
             if field == "id" and "_id" in result:
                 entry.update({field: doc_id})
             if field in result['_source']:
                 entry.update({field: result['_source'][field]})
-        # # code disabled because it updates the column set on the go; must be fixed
-        # highlights = result.get('highlight')
-        # if 'context' in extra_columns and highlights:
-        #     hi_fields = highlights.keys()
-        #     for hf in hi_fields:
-        #         for index, hi in enumerate(highlights[hf]):
-        #             highlight_field_name = '{}{}{}'.format(
-        #                 hf, QUERY_CONTEXT_INFIX, index + 1)
-        #             field_set.update([highlight_field_name])
-        #             soup = BeautifulSoup(hi, 'html.parser')
-        #             entry.update({highlight_field_name: soup.get_text()})
+
+        if context_fields:
+            entry.update(
+                _query_in_context_values(result.get('highlight', {}), context_fields)
+            )
         if tags:
             entry.update(_tag_values(corpus, doc_id, tags))
         if include_link:

--- a/backend/download/create_csv.py
+++ b/backend/download/create_csv.py
@@ -108,14 +108,17 @@ def _results_csv_fieldnames(
 
 
 def _query_in_context_values(highlights: Dict, context_fields: List[str]) -> Dict:
-    values = {f: None for f in context_fields}
+    values = {}
 
     for field in context_fields:
+        col = _query_in_context_column(field)
         snippets = highlights.get(field)
         if snippets:
             plain_text_snippets = map(strip_tags, snippets)
             value = '\n\n'.join(plain_text_snippets)
-            values[_query_in_context_column(field)] = value
+        else:
+            value = None
+        values[col] = value
 
     return values
 

--- a/backend/download/create_csv.py
+++ b/backend/download/create_csv.py
@@ -79,11 +79,16 @@ def _query_in_context_column(field: str) -> str:
     return f'query in context: {field}'
 
 
+
 def _query_in_context_fields(corpus: Corpus, query: Dict, extra_columns: List[str]) -> List[str]:
     if 'context' in extra_columns:
         corpus_fields = corpus.configuration.fields.all()
         query_fieldnames = get_search_fields(query) or [f.name for f in corpus_fields]
-        content_fields = corpus_fields.filter(display_type=FieldDisplayTypes.TEXT_CONTENT)
+        content_fields = corpus_fields.filter(
+            display_type=FieldDisplayTypes.TEXT_CONTENT,
+            downloadable=True,
+            hidden=False,
+        )
         return [ f.name for f in content_fields if f.name in query_fieldnames ]
 
 

--- a/backend/download/tasks.py
+++ b/backend/download/tasks.py
@@ -50,7 +50,7 @@ def make_download(request_json, download_id, download_size=None, user=None):
     filepath = create_csv.search_results_csv(
         results,
         request_json['fields'],
-        query.get_query_text(es_query),
+        es_query,
         download_id,
         corpus,
         user,

--- a/backend/download/tests/test_csv_results.py
+++ b/backend/download/tests/test_csv_results.py
@@ -9,6 +9,7 @@ from addcorpus.models import Corpus
 from es.search import hits
 from download import create_csv
 from tag.conftest import *
+from visualization import query as query_utils
 
 ### SEARCH RESULTS
 
@@ -22,25 +23,20 @@ mock_es_result = {
         },
         "max_score": 4.22,
         "hits": [
-            {   "_index" : "parliament-netherlands",
+            {   "_index" : "test-mock-corpus",
                 "_type" : "_doc",
-                "_id": "nl.proc.ob.d.h-ek-19992000-552-587.1.19.1",
+                "_id": "1",
                 "_score" :  4.22,
                 "_source": {
-                    "speech_id" : "nl.proc.ob.d.h-ek-19992000-552-587.1.19.1",
-                    "speaker" : "Staatssecretaris Adelmund",
-                    "speaker_id" : "nl.m.02500",
-                    "role" : "Government",
-                    "party" : "null",
-                    "party_id" : "null",
-                    "page" : "552-587",
-                    "column" : "null",
-                    "speech": "very long field"
+                    "date" : "1818-01-01",
+                    "content" : "You will rejoice to hear that no disaster has accompanied the commencement of an enterprise which you have regarded with such evil forebodings.",
+                    "genre" : "Science fiction",
+                    "title" : "Frankenstein, or, the Modern Prometheus",
                 },
                 "highlight" : {
-                    "speech" : [
-                        "Het gaat om een driehoek waarin <em>testen</em> en toetsen een",
-                        "om de highlights te <em>testen</em>"
+                    "content" : [
+                        "that no <em>disaster</em> has accompanied",
+                        "with such <em>evil</em> forebodings."
                     ]
                 }
             }
@@ -51,23 +47,38 @@ mock_es_result = {
 
 @pytest.fixture()
 def result_csv_with_highlights(csv_directory, small_mock_corpus, auth_user):
-    route = 'parliament-netherlands?query=test'
-    fields = ['speech']
+    query = query_utils.set_query_text(query_utils.MATCH_ALL, 'disaster evil')
+    fields = ['content']
+    corpus = Corpus.objects.get(name=small_mock_corpus)
     file = create_csv.search_results_csv(
-        hits(mock_es_result), fields, route, 0, small_mock_corpus, auth_user
+        hits(mock_es_result), fields, query, 0, corpus, auth_user, ['context']
     )
     return file
 
 
-def test_create_csv(result_csv_with_highlights):
-    counter = 0
+def test_query_in_context_fields(small_mock_corpus, small_mock_corpus_specs):
+    query = query_utils.set_query_text(query_utils.MATCH_ALL, 'test')
+    corpus = Corpus.objects.get(name=small_mock_corpus)
+    content_field = small_mock_corpus_specs['content_field']
+
+    assert not create_csv._query_in_context_fields(corpus, query, [])
+    assert create_csv._query_in_context_fields(corpus, query, ['context']) == [content_field]
+
+    other_fields = [f for f in small_mock_corpus_specs['fields'] if f != content_field]
+    query_other_fields = query_utils.set_search_fields(query, other_fields)
+    assert not create_csv._query_in_context_fields(corpus, query_other_fields, ['context'])
+
+
+def test_csv_query_in_context(result_csv_with_highlights):
     with open(result_csv_with_highlights) as f:
         csv_output = csv.DictReader(f, delimiter=';', quotechar='"')
-        assert csv_output != None
-        for row in csv_output:
-            counter += 1
-            assert 'speech' in row
-        assert counter == 1
+        rows = list(row for row in csv_output)
+        assert len(rows) == 1
+        assert csv_output.fieldnames == ['query', 'content', 'query in context: content']
+        context = rows[0]['query in context: content']
+        assert 'disaster' in context
+        assert 'forebodings' in context
+
 
 def test_csv_fieldnames(mock_corpus_results_csv, mock_corpus_specs):
     with open(mock_corpus_results_csv) as csv_file:

--- a/backend/download/tests/test_csv_results.py
+++ b/backend/download/tests/test_csv_results.py
@@ -78,6 +78,7 @@ def test_csv_query_in_context(result_csv_with_highlights):
         context = rows[0]['query in context: content']
         assert 'disaster' in context
         assert 'forebodings' in context
+        assert rows[0]['content'] == mock_es_result['hits']['hits'][0]['_source']['content']
 
 
 def test_csv_fieldnames(mock_corpus_results_csv, mock_corpus_specs):

--- a/frontend/src/app/download/download.component.html
+++ b/frontend/src/app/download/download.component.html
@@ -58,8 +58,7 @@
                         </label>
                     </li>
                     <li>
-                        <label *ngIf="queryModel.queryText" hidden>
-                            <!-- TODO: show this option when query-in-context download is fixed -->
+                        <label *ngIf="queryModel.queryText">
                             <input  type="checkbox"
                                 [checked]="(resultsConfig.highlight$ | async) !== undefined"
                                 (change)="onHighlightChange($event)">

--- a/frontend/src/app/download/download.component.ts
+++ b/frontend/src/app/download/download.component.ts
@@ -86,9 +86,9 @@ export class DownloadComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.corpus) {
-            this.fieldOptions = _.filter(this.corpus?.fields, 'downloadable').map(f => ({
-                value: f.name, label: f.displayName
-            }));
+            this.fieldOptions = this.corpus?.fields
+                .filter(f => f.downloadable && !f.hidden)
+                .map(f => ({value: f.name, label: f.displayName}));
             this.fieldSelection = _.filter(this.corpus?.fields, 'csvCore').map(f => f.name);
         }
         if (changes.queryModel) {


### PR DESCRIPTION
Restores the option to include "query in context" snippets in CSV downloads (resolves #1633)

This option had been disabled because the old format used a variable number of columns for snippets, which meant that all documents had to be fetched (and stored in memory) before the column names of the CSV could be resolved. This update uses a different format. Each content field has a single "query in context" column that contains all snippets from that field.