### PR TITLE
Bugfix/highlight stemmed fields

### DIFF
--- a/backend/addcorpus/python_corpora/corpus.py
+++ b/backend/addcorpus/python_corpora/corpus.py
@@ -187,20 +187,6 @@ class CorpusDefinition(Reader):
         '''
         return self.word_model_path is not None and isdir(self.word_model_path)
 
-    @property
-    def new_highlight(self):
-        '''
-        if the corpus has been re-indexed using the top-level term vector 'with_positions_offsets'
-        for the main content field, needed for the updated highlighter
-        TODO: remove this property and its references when all corpora are reindexed using the
-        current definitions (with the top-level term vector for speech)
-        '''
-        try:
-            highlight_corpora = settings.NEW_HIGHLIGHT_CORPORA
-        except Exception:
-            return False
-        return self.title in highlight_corpora
-
     '''
     Allow the downloading of source images
     '''

--- a/backend/ianalyzer/settings.py
+++ b/backend/ianalyzer/settings.py
@@ -86,10 +86,6 @@ CELERY_RESULT_BACKEND = os.getenv('CELERY_BROKER', 'redis://')
 # url to the frontend for generating email links
 BASE_URL = 'http://localhost:4200'
 
-# list of corpora that have been re-indexed using the top-level term vector
-# for main content fields, needed for the new highlighter
-NEW_HIGHLIGHT_CORPORA = []
-
 DEFAULT_FROM_EMAIL = 'ianalyzer@ianalyzer.dev'
 
 LOGGING = {

--- a/documentation/Django-project-settings.md
+++ b/documentation/Django-project-settings.md
@@ -109,12 +109,6 @@ The maximum number of documents that is analysed in the wordcloud (a.k.a. "most 
 
 The base URL for the application. This URL can be used to generate links to the frontend in emails and citation templates.
 
-### `NEW_HIGHLIGHT_CORPORA`
-
-List of corpora that have been re-indexed, so that the top-level term vectors for main content fields include positions and offsets. This is needed for the updated highlight functionality that was introduced in version 4.2.0 of I-analyzer.
-
-The list should contain the _titles_ (not names) of updated corpora. You only need to list corpora with a Python definition; legacy highlighting is not supported for database-only corpora.
-
 ### `SAML_GROUP_NAME`
 
 Optional, should be a string.

--- a/frontend/src/app/document/metadata-field/metadata-field.component.html
+++ b/frontend/src/app/document/metadata-field/metadata-field.component.html
@@ -2,9 +2,9 @@
     <div *ngSwitchCase="'text'"
         [innerHtml]="field | elasticsearchHighlight:document | paragraph">
     </div>
-    <ng-container *ngSwitchCase="'keyword'">
-        {{ document.fieldValue(field) | keyword }}
-    </ng-container>
+    <div *ngSwitchCase="'keyword'"
+         [innerHTML]="field | elasticsearchHighlight:document | keyword">
+    </div>
     <ng-container *ngSwitchCase="'date'">
         {{ document.fieldValue(field) | date:'mediumDate' }}
     </ng-container>

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -65,7 +65,6 @@ export interface ApiCorpusField {
     visualizations: string[];
     visualization_sort: string | null;
     es_mapping: any;
-    positionsOffsets?: boolean;
     indexed: boolean;
     hidden: boolean;
     required: boolean;
@@ -89,7 +88,7 @@ export class CorpusField {
     visualizations?: string[];
     visualizationSort?: string;
     multiFields?: string[];
-    positionsOffsets?: boolean;
+    fastVectorHighlight?: boolean;
     hidden: boolean;
     sortable: boolean;
     searchable: boolean;
@@ -111,7 +110,7 @@ export class CorpusField {
         this.multiFields = data['es_mapping']?.fields
             ? Object.keys(data['es_mapping'].fields)
             : undefined;
-        this.positionsOffsets = data['es_mapping']?.term_vector ? true : false;
+        this.fastVectorHighlight = data['es_mapping']?.term_vector?.startsWith('with_positions_offsets')
         this.hidden = data.hidden;
         this.sortable = data.sortable;
         this.searchable = data.searchable;

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -31,7 +31,6 @@ export class Corpus {
         public category: string,
         public hasNamedEntities: boolean,
         public documentContext?: DocumentContext,
-        public newHighlight?: boolean,
         public defaultSort?: SortState,
         public languageField?: CorpusField,
     ) { }

--- a/frontend/src/app/services/corpus.service.ts
+++ b/frontend/src/app/services/corpus.service.ts
@@ -95,7 +95,6 @@ export class CorpusService {
             data.category,
             data.has_named_entities,
             this.parseDocumentContext(data.document_context, allFields),
-            data.new_highlight,
             this.parseDefaultSort(data.default_sort, allFields),
             findByName(allFields, data.language_field),
         );

--- a/frontend/src/app/services/download.service.spec.ts
+++ b/frontend/src/app/services/download.service.spec.ts
@@ -40,14 +40,13 @@ describe('DownloadService', () => {
         const size = 1;
         const route = `/search/${query.corpus.name}`;
         const sort: SortState = [query.corpus.fields[2], 'desc'];
-        const highlight = 200;
         const options: DownloadOptions = {
             encoding: 'utf-8',
         };
 
         spyOn(apiService, 'download').and.returnValue(Promise.resolve({}));
         const fieldNames = query.corpus.fields.map(field => field.name)
-        service.download(query.corpus, query, fieldNames, size, route, sort, highlight, options, []);
+        service.download(query.corpus, query, fieldNames, size, route, sort, undefined, options, []);
         const expectedBody: LimitedResultsDownloadParameters = {
             corpus: query.corpus.name,
             fields: ['genre', 'content', 'date'],
@@ -66,13 +65,6 @@ describe('DownloadService', () => {
                     },
                 },
                 sort: [{ date: 'desc' }],
-                highlight: {
-                    fragment_size: highlight,
-                    pre_tags: ['<mark class="highlight">'],
-                    post_tags: ['</mark>'],
-                    order: 'score',
-                    fields: [{ content: {} }],
-                },
                 from: 0,
                 size,
             },

--- a/frontend/src/app/utils/es-query.spec.ts
+++ b/frontend/src/app/utils/es-query.spec.ts
@@ -44,17 +44,31 @@ describe('es-query utils', () => {
         });
     });
 
-    it('should make a highlight specification', () => {
-        expect(makeHighlightSpecification(corpusFactory(), 'test', [], undefined)).toEqual({});
-        expect(makeHighlightSpecification(corpusFactory(), 'test', [], 100)).toEqual({
-            highlight: {
-                fragment_size: 100,
-                pre_tags: ['<mark class="highlight">'],
-                post_tags: ['</mark>'],
-                order: 'score',
-                fields: [{content: {}}]
-            }
+    describe('makeHighlightSpecification', () => {
+        it('should make a highlight specification', () => {
+            expect(_.keys(
+                makeHighlightSpecification(corpusFactory(), 'test', [], undefined)
+            )).toEqual([]);
+            expect(_.keys(
+                makeHighlightSpecification(corpusFactory(), 'test', [], 100)
+            )).toEqual(['highlight']);
         });
+
+        it('should select highlight fields', () => {
+            const corpus = corpusFactory();
+            corpus.fields[0] = keywordFieldFactory(true); // corpus now has 2 searchable fields
+
+            const highlightedFields = (spec) => spec.highlight.fields.map(f => _.keys(f)[0]);
+
+            expect(highlightedFields(
+                makeHighlightSpecification(corpus, 'test', [], 100)
+            )).toContain('content')
+
+            expect(highlightedFields(
+                makeHighlightSpecification(corpus, 'test', [corpus.fields[0]], 100)
+            )).not.toContain('content');
+        });
+
     });
 
     it('should create an API query for paged results', () => {

--- a/frontend/src/app/utils/es-query.spec.ts
+++ b/frontend/src/app/utils/es-query.spec.ts
@@ -75,20 +75,16 @@ describe('es-query utils', () => {
             const corpus = corpusFactory();
             const makeSpec = (fields: CorpusField[]) =>
                 makeHighlightSpecification(corpus, 'test', fields, 100);
-            expect(
-                _.get(makeSpec([]), [0, 'content', 'matched_fields'])
-            ).toEqual(['content', 'content.stemmed']);
+            const matchedFields = spec => spec.highlight.fields[0].content.matched_fields;
+
+            expect(matchedFields(makeSpec([]))).toEqual(['content', 'content.stemmed']);
 
             const searchFields = searchFieldOptions(corpus);
             const baseField = findByName(searchFields, 'content');
             const stemmedField = findByName(searchFields, 'content.stemmed');
 
-            expect(
-                _.get(makeSpec([baseField]), [0, 'content', 'matched_fields'])
-            ).toEqual(['content']);
-            expect(
-                _.get(makeSpec([stemmedField]), [0, 'content', 'matched_fields'])
-            ).toEqual(['content.stemmed']);
+            expect(matchedFields(makeSpec([baseField]))).toEqual(['content']);
+            expect(matchedFields(makeSpec([stemmedField]))).toEqual(['content.stemmed']);
 
         })
     });

--- a/frontend/src/app/utils/es-query.spec.ts
+++ b/frontend/src/app/utils/es-query.spec.ts
@@ -45,9 +45,8 @@ describe('es-query utils', () => {
     });
 
     it('should make a highlight specification', () => {
-        expect(makeHighlightSpecification(corpusFactory(), 'test', undefined)).toEqual({});
-
-        expect(makeHighlightSpecification(corpusFactory(), 'test', 100)).toEqual({
+        expect(makeHighlightSpecification(corpusFactory(), 'test', [], undefined)).toEqual({});
+        expect(makeHighlightSpecification(corpusFactory(), 'test', [], 100)).toEqual({
             highlight: {
                 fragment_size: 100,
                 pre_tags: ['<mark class="highlight">'],

--- a/frontend/src/app/utils/es-query.ts
+++ b/frontend/src/app/utils/es-query.ts
@@ -106,7 +106,7 @@ export const makeHighlightSpecification = (corpus: Corpus, queryText?: string, h
                 field.positionsOffsets &&
                 // add matched_fields for stemmed highlighting
                 // ({ [field.name]: {"type": "fvh", "matched_fields": ["speech", "speech.stemmed"] }}):
-                corpus.newHighlight
+                corpus['newHighlight']
                     ? {
                           [field.name]: {
                               type: 'fvh',

--- a/frontend/src/app/utils/es-query.ts
+++ b/frontend/src/app/utils/es-query.ts
@@ -22,6 +22,7 @@ import { TagFilter } from '@models/tag-filter';
 import { PageResultsParameters } from '@models/page-results';
 import { DeepPartial } from 'chart.js/dist/types/utils';
 import { SimpleStore } from '../store/simple-store';
+import { searchFieldOptions } from './search-fields';
 
 // conversion from query model -> elasticsearch query language
 
@@ -90,18 +91,22 @@ export const makeSortSpecification = (sortBy: SortBy, sortDirection: SortDirecti
     }
 };
 
+const highlightFields = (corpus: Corpus, searchFields: CorpusField[]): CorpusField[]  => {
+    return searchFields.length ? searchFields : searchFieldOptions(corpus);
+}
+
 export const makeHighlightSpecification = (corpus: Corpus, queryText: string | undefined, searchFields: CorpusField[], highlightSize?: number) => {
     if (!queryText || !highlightSize) {
         return {};
     }
-    const highlightFields = corpus.fields.filter(field => field.searchable);
+    const fields = highlightFields(corpus, searchFields);
     return {
         highlight: {
             fragment_size: highlightSize,
             pre_tags: ['<mark class="highlight">'],
             post_tags: ['</mark>'],
             order: 'score',
-            fields: highlightFields.map((field) =>
+            fields: fields.map((field) =>
                 field.displayType === 'text_content' &&
                 field.positionsOffsets &&
                 // add matched_fields for stemmed highlighting

--- a/frontend/src/app/utils/es-query.ts
+++ b/frontend/src/app/utils/es-query.ts
@@ -103,12 +103,14 @@ const includeHighlight = (field: CorpusField, highlightFields: string[]): boolea
     _.some(highlightFields, f => baseFieldName(f) == field.name);
 
 const makeFieldHighlightSpec = (field: CorpusField, highlightFields: string[]) => {
-    if (field.positionsOffsets && field.multiFields) {
-        const matchedFields = highlightFields.filter(f => baseFieldName(f) == field.name);
-        return { [field.name]: { type: 'fvh', matched_fields: matchedFields }};
-    } else {
-        return { [field.name]: {} }
+    const spec = {};
+    if (field.positionsOffsets) {
+        spec['type'] = 'fvh';
     }
+    if (field.multiFields) {
+        spec['matched_fields'] = highlightFields.filter(f => baseFieldName(f) == field.name);
+    }
+    return { [field.name]: spec };
 };
 
 export const makeHighlightSpecification = (corpus: Corpus, queryText: string | undefined, searchFields: CorpusField[], highlightSize?: number) => {

--- a/frontend/src/app/utils/es-query.ts
+++ b/frontend/src/app/utils/es-query.ts
@@ -104,7 +104,7 @@ const includeHighlight = (field: CorpusField, highlightFields: string[]): boolea
 
 const makeFieldHighlightSpec = (field: CorpusField, highlightFields: string[]) => {
     const spec = {};
-    if (field.positionsOffsets) {
+    if (field.fastVectorHighlight) {
         spec['type'] = 'fvh';
     }
     if (field.multiFields) {

--- a/frontend/src/app/utils/es-query.ts
+++ b/frontend/src/app/utils/es-query.ts
@@ -90,7 +90,7 @@ export const makeSortSpecification = (sortBy: SortBy, sortDirection: SortDirecti
     }
 };
 
-export const makeHighlightSpecification = (corpus: Corpus, queryText?: string, highlightSize?: number) => {
+export const makeHighlightSpecification = (corpus: Corpus, queryText: string | undefined, searchFields: CorpusField[], highlightSize?: number) => {
     if (!queryText || !highlightSize) {
         return {};
     }
@@ -173,7 +173,7 @@ export const resultsParamsToAPIQuery = (queryModel: QueryModel, params: PageResu
     const query = queryModel.toAPIQuery();
 
     const sort = makeSortSpecification(...params.sort);
-    const highlight = makeHighlightSpecification(queryModel.corpus, queryModel.queryText, params.highlight);
+    const highlight = makeHighlightSpecification(queryModel.corpus, queryModel.queryText, queryModel.searchFields, params.highlight);
     const addToQuery: DeepPartial<APIQuery> = {
         es_query: {
             ...sort,

--- a/frontend/src/app/utils/es-query.ts
+++ b/frontend/src/app/utils/es-query.ts
@@ -91,8 +91,8 @@ export const makeSortSpecification = (sortBy: SortBy, sortDirection: SortDirecti
     }
 };
 
-const highlightFieldNames = (corpus: Corpus, searchFields: CorpusField[]): string[]  => {
-    const fields = searchFields.length ? searchFields : searchFieldOptions(corpus);
+const highlightFieldNames = (corpus: Corpus, searchFields?: CorpusField[]): string[]  => {
+    const fields = searchFields?.length ? searchFields : searchFieldOptions(corpus);
     return fields.map(f => f.name);
 };
 

--- a/frontend/src/mock-data/corpus.ts
+++ b/frontend/src/mock-data/corpus.ts
@@ -164,7 +164,6 @@ export const corpusFactory = () =>
         'Books',
         false,
         { contextFields: [], displayName: null },
-        false,
         [undefined, 'desc'],
     );
 


### PR DESCRIPTION
- Matches from stemmed fields are shown in highlights (close #1853)
- Highlights are only shown for search fields in the query
- Fixed related bug: matches in keyword/text multifields are now also highlighted
- Removes (obsolete) "new highlight" setting from the backend
